### PR TITLE
feat: add `typeIcons` to `FancyReporter` options

### DIFF
--- a/src/reporters/fancy.js
+++ b/src/reporters/fancy.js
@@ -12,15 +12,14 @@ const DEFAULTS = {
     date: true,
     colors: true,
     compact: false
+  },
+  typeIcons: {
+    info: figures('ℹ'),
+    success: figures('✔'),
+    debug: figures('›'),
+    trace: figures('›'),
+    log: ''
   }
-}
-
-const TYPE_ICONS = {
-  info: figures('ℹ'),
-  success: figures('✔'),
-  debug: figures('›'),
-  trace: figures('›'),
-  log: ''
 }
 
 export default class FancyReporter extends BasicReporter {
@@ -49,7 +48,7 @@ export default class FancyReporter extends BasicReporter {
       return chalkBgColor(typeColor).black(` ${logObj.type.toUpperCase()} `)
     }
 
-    const _type = typeof TYPE_ICONS[logObj.type] === 'string' ? TYPE_ICONS[logObj.type] : (logObj.icon || logObj.type)
+    const _type = typeof this.options.typeIcons[logObj.type] === 'string' ? this.options.typeIcons[logObj.type] : (logObj.icon || logObj.type)
     return _type ? chalkColor(typeColor)(_type) : ''
   }
 

--- a/types/consola.d.ts
+++ b/types/consola.d.ts
@@ -146,6 +146,7 @@ export declare class BasicReporter implements ConsolaReporter {
 
 export interface FancyReporterOptions extends BasicReporterOptions{
   secondaryColor?: string;
+  typeIcons?: Partial<Record<logType, string>>;
 }
 
 export declare class FancyReporter extends BasicReporter {


### PR DESCRIPTION
Allows you to customize the icons used in the `FancyReporter`.

This allows users to disable the usage of icons:

```js
new FancyReporter({ typeIcons: {} });
```

Or specify their own icon set:

```js
new FancyReporter({
  typeIcons: {
    info: 'i',
  },
});
```