### PR TITLE
feat: re-export `chalk`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,6 @@ export { default as Types } from './types'
 export { LogLevel } from './logLevels'
 export { isLogObj } from './utils'
 export { assignGlobalConsola } from './utils/global'
+export { chalkBgColor, chalkColor, chalk } from './utils/chalk'
 
 export * from './reporters'

--- a/src/utils/chalk.js
+++ b/src/utils/chalk.js
@@ -2,6 +2,8 @@ import chalk from 'chalk'
 
 const _colorCache = {}
 
+export { chalk }
+
 export function chalkColor (name) {
   let color = _colorCache[name]
   if (color) {


### PR DESCRIPTION
This allows users to construct custom colors without duplicating the color library.