### PR TITLE
feat: `consola.prompt` util

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,17 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Prompt support is based on https://github.com/natemoo-re/clack/
+
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐨 Consola
 
-> Elegant Console Logger for Node.js and Browser
+> Elegant Console Wrapper
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
@@ -20,6 +20,7 @@
 ⏯&nbsp; Pause/Resume support<br>
 👻&nbsp; Mocking support<br>
 👮‍♂️&nbsp; Spam prevention by throttling logs<br>
+❯&nbsp; Interactive prompt support powered by [`clack`](https://github.com/natemoo-re/clack)<br>
 
 ## Installation
 
@@ -70,6 +71,12 @@ Log to all reporters.
 Example: `consola.info('Message')`
 
 A list of available types can be found [here](./src/types.js).
+
+### `await prompt(message, { type })`
+
+Show an input prompt. Type can either of `text`, `confirm`, `select` or `multiselect`.
+
+See [examples/prompt.ts](./examples/prompt.ts) for usage examples.
 
 #### `addReporter(reporter)`
 

--- a/examples/prompt.ts
+++ b/examples/prompt.ts
@@ -1,0 +1,33 @@
+import { consola } from "./utils";
+
+async function main() {
+  const name = await consola.prompt("What is your name?", {
+    placeholder: "Not sure",
+    initial: "java",
+  });
+
+  const confirmed = await consola.prompt("Do you want to continue?", {
+    type: "confirm",
+  });
+
+  const projectType = await consola.prompt("Pick a project type.", {
+    type: "select",
+    options: [
+      "TypeScript",
+      "TypeScript",
+      { label: "CoffeeScript", value: "CoffeeScript", hint: "oh no" },
+    ],
+  });
+
+  const tools = await consola.prompt("Select additional tools.", {
+    type: "multiselect",
+    options: [
+      { value: "eslint", label: "ESLint", hint: "recommended" },
+      { value: "prettier", label: "Prettier" },
+      { value: "gh-action", label: "GitHub Action" },
+    ],
+    required: false,
+  });
+}
+
+main();

--- a/examples/prompt.ts
+++ b/examples/prompt.ts
@@ -21,12 +21,12 @@ async function main() {
 
   const tools = await consola.prompt("Select additional tools.", {
     type: "multiselect",
+    required: false,
     options: [
       { value: "eslint", label: "ESLint", hint: "recommended" },
       { value: "prettier", label: "Prettier" },
       { value: "gh-action", label: "GitHub Action" },
     ],
-    required: false,
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "consola",
   "version": "3.0.0-1",
-  "description": "Elegant Console Logger for Node.js and Browser",
+  "description": "Elegant Console Wrapper",
   "keywords": [
     "console",
     "logger",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test": "pnpm lint && pnpm build && pnpm vitest run --coverage"
   },
   "devDependencies": {
+    "@clack/core": "^0.3.2",
     "@types/node": "^18.15.10",
     "@vitest/coverage-c8": "^0.29.8",
     "changelogen": "^0.5.2",
@@ -53,14 +54,16 @@
     "eslint": "^8.36.0",
     "eslint-config-unjs": "^0.1.0",
     "figures": "^5.0.0",
+    "is-unicode-supported": "^1.3.0",
     "jiti": "^1.18.2",
     "lodash": "^4.17.21",
     "prettier": "^2.8.7",
     "sentencer": "^0.2.1",
+    "sisteransi": "^1.0.5",
     "std-env": "^3.3.2",
     "string-width": "^5.1.2",
     "typescript": "^5.0.2",
-    "unbuild": "^1.1.2",
+    "unbuild": "^1.2.0",
     "vitest": "^0.29.8",
     "winston": "^3.8.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,9 @@
 lockfileVersion: '6.0'
 
 devDependencies:
+  '@clack/core':
+    specifier: ^0.3.2
+    version: 0.3.2
   '@types/node':
     specifier: ^18.15.10
     version: 18.15.10
@@ -22,6 +25,9 @@ devDependencies:
   figures:
     specifier: ^5.0.0
     version: 5.0.0
+  is-unicode-supported:
+    specifier: ^1.3.0
+    version: 1.3.0
   jiti:
     specifier: ^1.18.2
     version: 1.18.2
@@ -34,6 +40,9 @@ devDependencies:
   sentencer:
     specifier: ^0.2.1
     version: 0.2.1
+  sisteransi:
+    specifier: ^1.0.5
+    version: 1.0.5
   std-env:
     specifier: ^3.3.2
     version: 3.3.2
@@ -44,8 +53,8 @@ devDependencies:
     specifier: ^5.0.2
     version: 5.0.2
   unbuild:
-    specifier: ^1.1.2
-    version: 1.1.2
+    specifier: ^1.2.0
+    version: 1.2.0
   vitest:
     specifier: ^0.29.8
     version: 0.29.8
@@ -265,6 +274,13 @@ packages:
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
+  /@clack/core@0.3.2:
+    resolution: {integrity: sha512-FZnsNynwGDIDktx6PEZK1EuCkFpY4ldEX6VYvfl0dqeoLPb9Jpw1xoUXaVcGR8ExmYNm1w2vdGdJkEUYD/2pqg==}
+    dependencies:
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
     dev: true
 
   /@colors/colors@1.5.0:
@@ -2357,8 +2373,8 @@ packages:
       function-bind: 1.1.1
     dev: true
 
-  /hookable@5.5.2:
-    resolution: {integrity: sha512-9JZdvGuxXswyoT47M0xrg+IabnK76Ppc7qjf8JdFZu/IaCWflTHVf/ln/GzicraEnPONPIfxgk929rdYiOqv9w==}
+  /hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
     dev: true
 
   /hosted-git-info@2.8.9:
@@ -2797,13 +2813,6 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
-  /magic-string@0.29.0:
-    resolution: {integrity: sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.14
-    dev: true
-
   /magic-string@0.30.0:
     resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
@@ -2893,7 +2902,7 @@ packages:
     hasBin: true
     dev: true
 
-  /mkdist@1.2.0(typescript@4.9.5):
+  /mkdist@1.2.0(typescript@5.0.3):
     resolution: {integrity: sha512-UTqu/bXmIk/+VKNVgufAeMyjUcNy1dn9Bl7wL1zZlCKVrpDgj/VllmZBeh3ZCC/2HWqUrt6frNFTKt9TRZbNvQ==}
     hasBin: true
     peerDependencies:
@@ -2913,7 +2922,7 @@ packages:
       mlly: 1.2.0
       mri: 1.2.0
       pathe: 1.1.0
-      typescript: 4.9.5
+      typescript: 5.0.3
     dev: true
 
   /mlly@1.2.0:
@@ -3344,7 +3353,7 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup-plugin-dts@5.3.0(rollup@3.20.2)(typescript@4.9.5):
+  /rollup-plugin-dts@5.3.0(rollup@3.20.2)(typescript@5.0.3):
     resolution: {integrity: sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -3353,7 +3362,7 @@ packages:
     dependencies:
       magic-string: 0.30.0
       rollup: 3.20.2
-      typescript: 4.9.5
+      typescript: 5.0.3
     optionalDependencies:
       '@babel/code-frame': 7.18.6
     dev: true
@@ -3465,6 +3474,10 @@ packages:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
       is-arrayish: 0.3.2
+    dev: true
+
+  /sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
 
   /slash@3.0.0:
@@ -3795,14 +3808,14 @@ packages:
       is-typed-array: 1.1.10
     dev: true
 
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript@5.0.2:
+    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+    engines: {node: '>=12.20'}
     hasBin: true
     dev: true
 
-  /typescript@5.0.2:
-    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+  /typescript@5.0.3:
+    resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
     engines: {node: '>=12.20'}
     hasBin: true
     dev: true
@@ -3820,8 +3833,8 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /unbuild@1.1.2:
-    resolution: {integrity: sha512-EK5LeABThyn5KbX0eo5c7xKRQhnHVxKN8/e5Y+YQEf4ZobJB6OZ766756wbVqzIY/G/MvAfLbc6EwFPdSNnlpA==}
+  /unbuild@1.2.0:
+    resolution: {integrity: sha512-GcolNMBatav7FbRdLDR8BMbnYWMoKfxXdJIHibpBtx3GERN4GbbUD5h4RfGIFi+mjWPz4AphSz5gIg9FWNWw3Q==}
     hasBin: true
     dependencies:
       '@rollup/plugin-alias': 4.0.3(rollup@3.20.2)
@@ -3835,19 +3848,19 @@ packages:
       defu: 6.1.2
       esbuild: 0.17.14
       globby: 13.1.3
-      hookable: 5.5.2
+      hookable: 5.5.3
       jiti: 1.18.2
-      magic-string: 0.29.0
-      mkdist: 1.2.0(typescript@4.9.5)
+      magic-string: 0.30.0
+      mkdist: 1.2.0(typescript@5.0.3)
       mlly: 1.2.0
       mri: 1.2.0
       pathe: 1.1.0
       pkg-types: 1.0.2
       pretty-bytes: 6.1.0
       rollup: 3.20.2
-      rollup-plugin-dts: 5.3.0(rollup@3.20.2)(typescript@4.9.5)
+      rollup-plugin-dts: 5.3.0(rollup@3.20.2)(typescript@5.0.3)
       scule: 1.0.0
-      typescript: 4.9.5
+      typescript: 5.0.3
       untyped: 1.3.2
     transitivePeerDependencies:
       - sass

--- a/src/consola.ts
+++ b/src/consola.ts
@@ -15,7 +15,7 @@ import type { PromptOptions } from "./prompt";
 let paused = false;
 const queue: any[] = [];
 
-interface _ConsolaLoggers {
+export interface _ConsolaLoggers {
   // Built-in log levels
   fatal(message: ConsolaLogObject | any, ...args: any[]): void;
   error(message: ConsolaLogObject | any, ...args: any[]): void;

--- a/src/consola.ts
+++ b/src/consola.ts
@@ -10,6 +10,7 @@ import type {
   ConsolaMockFn,
   ConsolaReporterLogObject,
 } from "./types";
+import type { PromptOptions } from "./prompt";
 
 let paused = false;
 const queue: any[] = [];
@@ -102,6 +103,11 @@ export class Consola {
   get stderr() {
     // @ts-ignore
     return this._stderr || console._stderr; // eslint-disable-line no-console
+  }
+
+  async prompt<T extends PromptOptions>(message: string, opts: T) {
+    const { prompt } = await import("./prompt");
+    return prompt<any, any, T>(message, opts);
   }
 
   create(options: ConsolaOptions) {
@@ -265,7 +271,7 @@ export class Consola {
   }
 
   _logFn(defaults: ConsolaLogObject, args: any[], isRaw?: boolean) {
-    if ((defaults.level || 0) > this.level) {
+    if (((defaults.level as number) || 0) > this.level) {
       return this._async ? Promise.resolve(false) : false;
     }
 

--- a/src/consola.ts
+++ b/src/consola.ts
@@ -40,6 +40,7 @@ export class Consola {
   _mockFn: ConsolaMockFn | undefined;
   _throttle: any;
   _throttleMin: any;
+  _prompt: typeof import("./prompt").prompt | undefined;
 
   _lastLogSerialized: any;
   _lastLog: any;
@@ -62,6 +63,7 @@ export class Consola {
     this._mockFn = options.mockFn;
     this._throttle = options.throttle || 1000;
     this._throttleMin = options.throttleMin || 5;
+    this._prompt = options.prompt;
 
     // Create logger functions for current instance
     for (const type in this._types) {
@@ -105,9 +107,11 @@ export class Consola {
     return this._stderr || console._stderr; // eslint-disable-line no-console
   }
 
-  async prompt<T extends PromptOptions>(message: string, opts: T) {
-    const { prompt } = await import("./prompt");
-    return prompt<any, any, T>(message, opts);
+  prompt<T extends PromptOptions>(message: string, opts: T) {
+    if (!this._prompt) {
+      throw new Error("prompt is not supported!");
+    }
+    return this._prompt<any, any, T>(message, opts);
   }
 
   create(options: ConsolaOptions) {

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,16 +1,24 @@
-import { createConsola } from "./consola";
 import BrowserReporter from "./reporters/browser";
+import { createConsola as _createConsola } from "./consola";
+import type { ConsolaOptions } from "./types";
 
 export * from "./index.shared";
 
-function _createConsola() {
-  const consola = createConsola({
-    reporters: [new BrowserReporter({})],
+export function createConsola(options: Partial<ConsolaOptions> = {}) {
+  const consola = _createConsola({
+    reporters: options.reporters || [new BrowserReporter({})],
+    prompt(message, options = {}) {
+      if (options.type === "confirm") {
+        return Promise.resolve(confirm(message) as any);
+      }
+      return Promise.resolve(prompt(message));
+    },
+    ...options,
   });
   return consola;
 }
 
 export const consola = ((globalThis as any).consola =
-  (globalThis as any).consola || _createConsola());
+  (globalThis as any).consola || createConsola());
 
 export default consola;

--- a/src/index.shared.ts
+++ b/src/index.shared.ts
@@ -1,4 +1,4 @@
-export { Consola, createConsola } from "./consola";
+export { Consola } from "./consola";
 export { Types } from "./log.types";
 export { LogLevels } from "./log.levels";
 export { isLogObj } from "./utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,6 @@ function _getDefaultLogLevel() {
 }
 
 export const consola = ((globalThis as any).consola =
-  (globalThis as any).consola || _createConsola());
+  (globalThis as any).consola || createConsola());
 
 export default consola;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { isDebug, isTest, isCI } from "std-env";
 import { LogLevels } from "./log.levels";
-import type { LogLevel } from "./types";
+import type { ConsolaOptions, LogLevel } from "./types";
 import { BasicReporter, FancyReporter } from "./reporters";
-import { createConsola } from "./index.shared";
+import { createConsola as _createConsola } from "./consola";
 
 export * from "./index.shared";
 
-function _createConsola() {
+export function createConsola(options: Partial<ConsolaOptions> = {}) {
   // Log level
   let level = _getDefaultLogLevel();
   if (process.env.CONSOLA_LEVEL) {
@@ -14,9 +14,13 @@ function _createConsola() {
   }
 
   // Create new consola instance
-  const consola = createConsola({
+  const consola = _createConsola({
     level: level as LogLevel,
-    reporters: [isCI || isTest ? new BasicReporter({}) : new FancyReporter({})],
+    prompt: (...args) => import("./prompt").then((m) => m.prompt(...args)),
+    reporters: options.reporters || [
+      isCI || isTest ? new BasicReporter({}) : new FancyReporter({}),
+    ],
+    ...options,
   });
 
   return consola;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,0 +1,90 @@
+import { text, confirm, select, multiselect } from "./utils/prompt";
+
+type SelectOption = {
+  label: string;
+  value: string;
+  hint?: string;
+};
+
+export type TextOptions = {
+  type?: "text";
+  default?: string;
+  placeholder?: string;
+  initial?: string;
+};
+
+export type ConfirmOptions = {
+  type: "confirm";
+  initial?: boolean;
+};
+
+export type SelectOptions = {
+  type: "select";
+  initial?: string;
+  options: (SelectOption | string)[];
+};
+
+export type MultiSelectOptions = {
+  type: "multiselect";
+  initial?: string;
+  options: string[] | SelectOption[];
+  required?: boolean;
+};
+
+export type PromptOptions =
+  | TextOptions
+  | ConfirmOptions
+  | SelectOptions
+  | MultiSelectOptions;
+
+type inferPromptReturnType<T extends PromptOptions> = T extends TextOptions
+  ? string
+  : T extends ConfirmOptions
+  ? boolean
+  : string[];
+
+export async function prompt<
+  _ = any,
+  __ = any,
+  T extends PromptOptions = TextOptions
+>(
+  message: string,
+  opts: PromptOptions = {}
+): Promise<inferPromptReturnType<T>> {
+  if (!opts.type || opts.type === "text") {
+    return (await text({
+      message,
+      defaultValue: opts.default,
+      placeholder: opts.placeholder,
+      initialValue: opts.initial as string,
+    })) as any;
+  }
+
+  if (opts.type === "confirm") {
+    return (await confirm({
+      message,
+      initialValue: opts.initial,
+    })) as any;
+  }
+
+  if (opts.type === "select") {
+    return (await select({
+      message,
+      options: opts.options.map((o) =>
+        typeof o === "string" ? { value: o, label: o } : o
+      ),
+    })) as any;
+  }
+
+  if (opts.type === "multiselect") {
+    return (await multiselect({
+      message,
+      options: opts.options.map((o) =>
+        typeof o === "string" ? { value: o, label: o } : o
+      ),
+      required: opts.required,
+    })) as any;
+  }
+
+  throw new Error(`Unknown prompt type: ${opts.type}`);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export interface ConsolaOptions {
   mockFn?: ConsolaMockFn;
   throttle?: number;
   throttleMin?: number;
+  prompt?: typeof import("./prompt").prompt | undefined;
 }
 
 export interface BasicReporterOptions {

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -28,10 +28,10 @@ export { isCancel } from "@clack/core";
 
 const unicode = isUnicodeSupported();
 const s = (c: string, fallback: string) => (unicode ? c : fallback);
-const S_STEP_ACTIVE = ""; // s("◆", "*");
+const S_STEP_ACTIVE = s("❯", ">");
 const S_STEP_CANCEL = s("■", "x");
 const S_STEP_ERROR = s("▲", "x");
-const S_STEP_SUBMIT = ""; // s("◇", "o");
+const S_STEP_SUBMIT = s("✔", "√");
 
 const S_BAR_START = ""; // s("┌", "T");
 const S_BAR = ""; // s("│", "|");
@@ -82,7 +82,7 @@ export const text = (opts: TextOptions) => {
     defaultValue: opts.defaultValue,
     initialValue: opts.initialValue,
     render() {
-      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)} ${
         opts.message
       }\n`;
       const placeholder = opts.placeholder
@@ -95,19 +95,19 @@ export const text = (opts: TextOptions) => {
         case "error":
           return `${title.trim()}\n${color.yellow(
             S_BAR
-          )}  ${value}\n${color.yellow(S_BAR_END)}  ${color.yellow(
+          )} ${value}\n${color.yellow(S_BAR_END)} ${color.yellow(
             this.error
           )}\n`;
         case "submit":
-          return `${title}${color.gray(S_BAR)}  ${color.dim(
+          return `${title}${color.gray(S_BAR)} ${color.dim(
             this.value || opts.placeholder
           )}`;
         case "cancel":
-          return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
+          return `${title}${color.gray(S_BAR)} ${color.strikethrough(
             color.dim(this.value ?? "")
           )}${this.value?.trim() ? "\n" + color.gray(S_BAR) : ""}`;
         default:
-          return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(
+          return `${title}${color.cyan(S_BAR)} ${value}\n${color.cyan(
             S_BAR_END
           )}\n`;
       }
@@ -125,7 +125,7 @@ export const password = (opts: PasswordOptions) => {
     validate: opts.validate,
     mask: opts.mask ?? S_PASSWORD_MASK,
     render() {
-      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)} ${
         opts.message
       }\n`;
       const value = this.valueWithCursor;
@@ -135,17 +135,17 @@ export const password = (opts: PasswordOptions) => {
         case "error":
           return `${title.trim()}\n${color.yellow(
             S_BAR
-          )}  ${masked}\n${color.yellow(S_BAR_END)}  ${color.yellow(
+          )} ${masked}\n${color.yellow(S_BAR_END)} ${color.yellow(
             this.error
           )}\n`;
         case "submit":
-          return `${title}${color.gray(S_BAR)}  ${color.dim(masked)}`;
+          return `${title}${color.gray(S_BAR)} ${color.dim(masked)}`;
         case "cancel":
-          return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
+          return `${title}${color.gray(S_BAR)} ${color.strikethrough(
             color.dim(masked ?? "")
           )}${masked ? "\n" + color.gray(S_BAR) : ""}`;
         default:
-          return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(
+          return `${title}${color.cyan(S_BAR)} ${value}\n${color.cyan(
             S_BAR_END
           )}\n`;
       }
@@ -167,20 +167,20 @@ export const confirm = (opts: ConfirmOptions) => {
     inactive,
     initialValue: opts.initialValue ?? true,
     render() {
-      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)} ${
         opts.message
       }\n`;
       const value = this.value ? active : inactive;
 
       switch (this.state) {
         case "submit":
-          return `${title}${color.gray(S_BAR)}  ${color.dim(value)}`;
+          return `${title}${color.gray(S_BAR)} ${color.dim(value)}`;
         case "cancel":
-          return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
+          return `${title}${color.gray(S_BAR)} ${color.strikethrough(
             color.dim(value)
           )}\n${color.gray(S_BAR)}`;
         default: {
-          return `${title}${color.cyan(S_BAR)}  ${
+          return `${title}${color.cyan(S_BAR)} ${
             this.value
               ? `${color.green(S_RADIO_ACTIVE)} ${active}`
               : `${color.dim(S_RADIO_INACTIVE)} ${color.dim(active)}`
@@ -236,23 +236,23 @@ export const select = <Options extends Option<Value>[], Value>(
     options: opts.options,
     initialValue: opts.initialValue,
     render() {
-      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)} ${
         opts.message
       }\n`;
 
       switch (this.state) {
         case "submit":
-          return `${title}${color.gray(S_BAR)}  ${opt(
+          return `${title}${color.gray(S_BAR)} ${opt(
             this.options[this.cursor],
             "selected"
           )}`;
         case "cancel":
-          return `${title}${color.gray(S_BAR)}  ${opt(
+          return `${title}${color.gray(S_BAR)} ${opt(
             this.options[this.cursor],
             "cancelled"
           )}\n${color.gray(S_BAR)}`;
         default: {
-          return `${title}${color.cyan(S_BAR)}  ${this.options
+          return `${title}${color.cyan(S_BAR)} ${this.options
             .map((option, i) =>
               opt(option, i === this.cursor ? "active" : "inactive")
             )
@@ -297,24 +297,24 @@ export const selectKey = <
     options: opts.options,
     initialValue: opts.initialValue,
     render() {
-      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)} ${
         opts.message
       }\n`;
 
       switch (this.state) {
         case "submit":
-          return `${title}${color.gray(S_BAR)}  ${opt(
+          return `${title}${color.gray(S_BAR)} ${opt(
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             this.options.find((opt) => opt.value === this.value)!,
             "selected"
           )}`;
         case "cancel":
-          return `${title}${color.gray(S_BAR)}  ${opt(
+          return `${title}${color.gray(S_BAR)} ${opt(
             this.options[0],
             "cancelled"
           )}\n${color.gray(S_BAR)}`;
         default: {
-          return `${title}${color.cyan(S_BAR)}  ${this.options
+          return `${title}${color.cyan(S_BAR)} ${this.options
             .map((option, i) =>
               opt(option, i === this.cursor ? "active" : "inactive")
             )
@@ -390,13 +390,13 @@ export const multiselect = <Options extends Option<Value>[], Value>(
       }
     },
     render() {
-      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)} ${
         opts.message
       }\n`;
 
       switch (this.state) {
         case "submit": {
-          return `${title}${color.gray(S_BAR)}  ${
+          return `${title}${color.gray(S_BAR)} ${
             this.options
               .filter(({ value }) => this.value.includes(value))
               .map((option) => opt(option, "submitted"))
@@ -408,7 +408,7 @@ export const multiselect = <Options extends Option<Value>[], Value>(
             .filter(({ value }) => this.value.includes(value))
             .map((option) => opt(option, "cancelled"))
             .join(color.dim(", "));
-          return `${title}${color.gray(S_BAR)}  ${
+          return `${title}${color.gray(S_BAR)} ${
             label.trim() ? `${label}\n${color.gray(S_BAR)}` : ""
           }`;
         }
@@ -417,7 +417,7 @@ export const multiselect = <Options extends Option<Value>[], Value>(
             .split("\n")
             .map((ln, i) =>
               i === 0
-                ? `${color.yellow(S_BAR_END)}  ${color.yellow(ln)}`
+                ? `${color.yellow(S_BAR_END)} ${color.yellow(ln)}`
                 : `   ${ln}`
             )
             .join("\n");
@@ -444,7 +444,7 @@ export const multiselect = <Options extends Option<Value>[], Value>(
           );
         }
         default: {
-          return `${title}${color.cyan(S_BAR)}  ${this.options
+          return `${title}${color.cyan(S_BAR)} ${this.options
             .map((option, i) => {
               const selected = this.value.includes(option.value);
               const active = i === this.cursor;
@@ -552,13 +552,13 @@ export const groupMultiselect = <Options extends Option<Value>[], Value>(
       }
     },
     render() {
-      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)} ${
         opts.message
       }\n`;
 
       switch (this.state) {
         case "submit": {
-          return `${title}${color.gray(S_BAR)}  ${this.options
+          return `${title}${color.gray(S_BAR)} ${this.options
             .filter(({ value }) => this.value.includes(value))
             .map((option) => opt(option, "submitted"))
             .join(color.dim(", "))}`;
@@ -568,7 +568,7 @@ export const groupMultiselect = <Options extends Option<Value>[], Value>(
             .filter(({ value }) => this.value.includes(value))
             .map((option) => opt(option, "cancelled"))
             .join(color.dim(", "));
-          return `${title}${color.gray(S_BAR)}  ${
+          return `${title}${color.gray(S_BAR)} ${
             label.trim() ? `${label}\n${color.gray(S_BAR)}` : ""
           }`;
         }
@@ -577,11 +577,11 @@ export const groupMultiselect = <Options extends Option<Value>[], Value>(
             .split("\n")
             .map((ln, i) =>
               i === 0
-                ? `${color.yellow(S_BAR_END)}  ${color.yellow(ln)}`
+                ? `${color.yellow(S_BAR_END)} ${color.yellow(ln)}`
                 : `   ${ln}`
             )
             .join("\n");
-          return `${title}${color.yellow(S_BAR)}  ${this.options
+          return `${title}${color.yellow(S_BAR)} ${this.options
             .map((option, i, options) => {
               const selected =
                 this.value.includes(option.value) ||
@@ -610,7 +610,7 @@ export const groupMultiselect = <Options extends Option<Value>[], Value>(
             .join(`\n${color.yellow(S_BAR)}  `)}\n${footer}\n`;
         }
         default: {
-          return `${title}${color.cyan(S_BAR)}  ${this.options
+          return `${title}${color.cyan(S_BAR)} ${this.options
             .map((option, i, options) => {
               const selected =
                 this.value.includes(option.value) ||
@@ -658,13 +658,13 @@ export const note = (message = "", title = "") => {
   const msg = lines
     .map(
       (ln) =>
-        `${color.gray(S_BAR)}  ${color.dim(ln)}${" ".repeat(
+        `${color.gray(S_BAR)} ${color.dim(ln)}${" ".repeat(
           len - strip(ln).length
         )}${color.gray(S_BAR)}`
     )
     .join("\n");
   process.stdout.write(
-    `${color.gray(S_BAR)}\n${color.green(S_STEP_SUBMIT)}  ${color.reset(
+    `${color.gray(S_BAR)}\n${color.green(S_STEP_SUBMIT)} ${color.reset(
       title
     )} ${color.gray(
       S_BAR_H.repeat(Math.max(len - title.length - 1, 1)) + S_CORNER_TOP_RIGHT
@@ -675,16 +675,16 @@ export const note = (message = "", title = "") => {
 };
 
 export const cancel = (message = "") => {
-  process.stdout.write(`${color.gray(S_BAR_END)}  ${color.red(message)}\n\n`);
+  process.stdout.write(`${color.gray(S_BAR_END)} ${color.red(message)}\n\n`);
 };
 
 export const intro = (title = "") => {
-  process.stdout.write(`${color.gray(S_BAR_START)}  ${title}\n`);
+  process.stdout.write(`${color.gray(S_BAR_START)} ${title}\n`);
 };
 
 export const outro = (message = "") => {
   process.stdout.write(
-    `${color.gray(S_BAR)}\n${color.gray(S_BAR_END)}  ${message}\n\n`
+    `${color.gray(S_BAR)}\n${color.gray(S_BAR_END)} ${message}\n\n`
   );
 };
 
@@ -700,8 +700,8 @@ export const log = {
     if (message) {
       const [firstLine, ...lines] = message.split("\n");
       parts.push(
-        `${symbol}  ${firstLine}`,
-        ...lines.map((ln) => `${color.gray(S_BAR)}  ${ln}`)
+        `${symbol} ${firstLine}`,
+        ...lines.map((ln) => `${color.gray(S_BAR)} ${ln}`)
       );
     }
     process.stdout.write(`${parts.join("\n")}\n`);
@@ -738,7 +738,7 @@ export const spinner = () => {
       message = message.replace(/\.?\.?\.$/, "");
       unblock = block();
       process.stdout.write(
-        `${color.gray(S_BAR)}\n${color.magenta("○")}  ${message}\n`
+        `${color.gray(S_BAR)}\n${color.magenta("○")} ${message}\n`
       );
       let i = 0;
       let dot = 0;
@@ -746,7 +746,7 @@ export const spinner = () => {
         const frame = frames[i];
         process.stdout.write(cursor.move(-999, -1));
         process.stdout.write(
-          `${color.magenta(frame)}  ${message}${
+          `${color.magenta(frame)} ${message}${
             Math.floor(dot) >= 1 ? ".".repeat(Math.floor(dot)).slice(0, 3) : ""
           }   \n`
         );
@@ -759,7 +759,7 @@ export const spinner = () => {
       process.stdout.write(erase.down(2));
       clearInterval(loop);
       process.stdout.write(
-        `${color.gray(S_BAR)}\n${color.green(S_STEP_SUBMIT)}  ${message}\n`
+        `${color.gray(S_BAR)}\n${color.green(S_STEP_SUBMIT)} ${message}\n`
       );
       unblock();
     },

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,0 +1,835 @@
+/**
+ * Based on @clak/propmts (MIT - Copyright (c) Nate Moore - Check LICENSE)
+ * https://github.com/natemoo-re/clack/blob/593f93d06c1a53c8424e9aaf0c1c63fbf6975527/packages/prompts/src/index.ts
+ *
+ * Forked to use custom symbols and colors
+ */
+
+import {
+  block,
+  ConfirmPrompt,
+  GroupMultiSelectPrompt,
+  isCancel,
+  MultiSelectPrompt,
+  PasswordPrompt,
+  SelectKeyPrompt,
+  SelectPrompt,
+  State,
+  TextPrompt,
+} from "@clack/core";
+
+import isUnicodeSupported from "is-unicode-supported";
+
+import * as color from "colorette";
+
+import { cursor, erase } from "sisteransi";
+
+export { isCancel } from "@clack/core";
+
+const unicode = isUnicodeSupported();
+const s = (c: string, fallback: string) => (unicode ? c : fallback);
+const S_STEP_ACTIVE = ""; // s("◆", "*");
+const S_STEP_CANCEL = s("■", "x");
+const S_STEP_ERROR = s("▲", "x");
+const S_STEP_SUBMIT = ""; // s("◇", "o");
+
+const S_BAR_START = ""; // s("┌", "T");
+const S_BAR = ""; // s("│", "|");
+const S_BAR_END = ""; // s("└", "—");
+
+const S_RADIO_ACTIVE = s("●", ">");
+const S_RADIO_INACTIVE = s("○", " ");
+const S_CHECKBOX_ACTIVE = s("◻", "[•]");
+const S_CHECKBOX_SELECTED = s("◼", "[+]");
+const S_CHECKBOX_INACTIVE = s("◻", "[ ]");
+const S_PASSWORD_MASK = s("▪", "•");
+
+const S_BAR_H = s("─", "-");
+const S_CORNER_TOP_RIGHT = s("╮", "+");
+const S_CONNECT_LEFT = s("├", "+");
+const S_CORNER_BOTTOM_RIGHT = s("╯", "+");
+
+const S_INFO = s("●", "•");
+const S_SUCCESS = s("◆", "*");
+const S_WARN = s("▲", "!");
+const S_ERROR = s("■", "x");
+
+const symbol = (state: State) => {
+  switch (state) {
+    case "initial":
+    case "active":
+      return color.cyan(S_STEP_ACTIVE);
+    case "cancel":
+      return color.red(S_STEP_CANCEL);
+    case "error":
+      return color.yellow(S_STEP_ERROR);
+    case "submit":
+      return color.green(S_STEP_SUBMIT);
+  }
+};
+
+export interface TextOptions {
+  message: string;
+  placeholder?: string;
+  defaultValue?: string;
+  initialValue?: string;
+  validate?: (value: string) => string | void;
+}
+export const text = (opts: TextOptions) => {
+  return new TextPrompt({
+    validate: opts.validate,
+    placeholder: opts.placeholder,
+    defaultValue: opts.defaultValue,
+    initialValue: opts.initialValue,
+    render() {
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+        opts.message
+      }\n`;
+      const placeholder = opts.placeholder
+        ? color.inverse(opts.placeholder[0]) +
+          color.dim(opts.placeholder.slice(1))
+        : color.inverse(color.hidden("_"));
+      const value = !this.value ? placeholder : this.valueWithCursor;
+
+      switch (this.state) {
+        case "error":
+          return `${title.trim()}\n${color.yellow(
+            S_BAR
+          )}  ${value}\n${color.yellow(S_BAR_END)}  ${color.yellow(
+            this.error
+          )}\n`;
+        case "submit":
+          return `${title}${color.gray(S_BAR)}  ${color.dim(
+            this.value || opts.placeholder
+          )}`;
+        case "cancel":
+          return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
+            color.dim(this.value ?? "")
+          )}${this.value?.trim() ? "\n" + color.gray(S_BAR) : ""}`;
+        default:
+          return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(
+            S_BAR_END
+          )}\n`;
+      }
+    },
+  }).prompt() as Promise<string | symbol>;
+};
+
+export interface PasswordOptions {
+  message: string;
+  mask?: string;
+  validate?: (value: string) => string | void;
+}
+export const password = (opts: PasswordOptions) => {
+  return new PasswordPrompt({
+    validate: opts.validate,
+    mask: opts.mask ?? S_PASSWORD_MASK,
+    render() {
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+        opts.message
+      }\n`;
+      const value = this.valueWithCursor;
+      const masked = this.masked;
+
+      switch (this.state) {
+        case "error":
+          return `${title.trim()}\n${color.yellow(
+            S_BAR
+          )}  ${masked}\n${color.yellow(S_BAR_END)}  ${color.yellow(
+            this.error
+          )}\n`;
+        case "submit":
+          return `${title}${color.gray(S_BAR)}  ${color.dim(masked)}`;
+        case "cancel":
+          return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
+            color.dim(masked ?? "")
+          )}${masked ? "\n" + color.gray(S_BAR) : ""}`;
+        default:
+          return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(
+            S_BAR_END
+          )}\n`;
+      }
+    },
+  }).prompt() as Promise<string | symbol>;
+};
+
+export interface ConfirmOptions {
+  message: string;
+  active?: string;
+  inactive?: string;
+  initialValue?: boolean;
+}
+export const confirm = (opts: ConfirmOptions) => {
+  const active = opts.active ?? "Yes";
+  const inactive = opts.inactive ?? "No";
+  return new ConfirmPrompt({
+    active,
+    inactive,
+    initialValue: opts.initialValue ?? true,
+    render() {
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+        opts.message
+      }\n`;
+      const value = this.value ? active : inactive;
+
+      switch (this.state) {
+        case "submit":
+          return `${title}${color.gray(S_BAR)}  ${color.dim(value)}`;
+        case "cancel":
+          return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
+            color.dim(value)
+          )}\n${color.gray(S_BAR)}`;
+        default: {
+          return `${title}${color.cyan(S_BAR)}  ${
+            this.value
+              ? `${color.green(S_RADIO_ACTIVE)} ${active}`
+              : `${color.dim(S_RADIO_INACTIVE)} ${color.dim(active)}`
+          } ${color.dim("/")} ${
+            !this.value
+              ? `${color.green(S_RADIO_ACTIVE)} ${inactive}`
+              : `${color.dim(S_RADIO_INACTIVE)} ${color.dim(inactive)}`
+          }\n${color.cyan(S_BAR_END)}\n`;
+        }
+      }
+    },
+  }).prompt() as Promise<boolean | symbol>;
+};
+
+type Primitive = Readonly<string | boolean | number>;
+
+type Option<Value> = Value extends Primitive
+  ? { value: Value; label?: string; hint?: string }
+  : { value: Value; label: string; hint?: string };
+
+export interface SelectOptions<Options extends Option<Value>[], Value> {
+  message: string;
+  options: Options;
+  initialValue?: Value;
+}
+
+export const select = <Options extends Option<Value>[], Value>(
+  opts: SelectOptions<Options, Value>
+) => {
+  const opt = (
+    option: Option<Value>,
+    state: "inactive" | "active" | "selected" | "cancelled"
+  ) => {
+    const label = option.label ?? String(option.value);
+    switch (state) {
+      case "active": {
+        return `${color.green(S_RADIO_ACTIVE)} ${label} ${
+          option.hint ? color.dim(`(${option.hint})`) : ""
+        }`;
+      }
+      case "selected": {
+        return `${color.dim(label)}`;
+      }
+      case "cancelled": {
+        return `${color.strikethrough(color.dim(label))}`;
+      }
+      // No default
+    }
+    return `${color.dim(S_RADIO_INACTIVE)} ${color.dim(label)}`;
+  };
+
+  return new SelectPrompt({
+    options: opts.options,
+    initialValue: opts.initialValue,
+    render() {
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+        opts.message
+      }\n`;
+
+      switch (this.state) {
+        case "submit":
+          return `${title}${color.gray(S_BAR)}  ${opt(
+            this.options[this.cursor],
+            "selected"
+          )}`;
+        case "cancel":
+          return `${title}${color.gray(S_BAR)}  ${opt(
+            this.options[this.cursor],
+            "cancelled"
+          )}\n${color.gray(S_BAR)}`;
+        default: {
+          return `${title}${color.cyan(S_BAR)}  ${this.options
+            .map((option, i) =>
+              opt(option, i === this.cursor ? "active" : "inactive")
+            )
+            .join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
+        }
+      }
+    },
+  }).prompt() as Promise<Value | symbol>;
+};
+
+export const selectKey = <
+  Options extends Option<Value>[],
+  Value extends string
+>(
+  opts: SelectOptions<Options, Value>
+) => {
+  const opt = (
+    option: Option<Value>,
+    state: "inactive" | "active" | "selected" | "cancelled" = "inactive"
+  ) => {
+    const label = option.label ?? String(option.value);
+    switch (state) {
+      case "selected": {
+        return `${color.dim(label)}`;
+      }
+      case "cancelled": {
+        return `${color.strikethrough(color.dim(label))}`;
+      }
+      case "active": {
+        return `${color.bgCyan(color.gray(` ${option.value} `))} ${label} ${
+          option.hint ? color.dim(`(${option.hint})`) : ""
+        }`;
+      }
+      // No default
+    }
+    return `${color.gray(
+      color.bgWhite(color.inverse(` ${option.value} `))
+    )} ${label} ${option.hint ? color.dim(`(${option.hint})`) : ""}`;
+  };
+
+  return new SelectKeyPrompt({
+    options: opts.options,
+    initialValue: opts.initialValue,
+    render() {
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+        opts.message
+      }\n`;
+
+      switch (this.state) {
+        case "submit":
+          return `${title}${color.gray(S_BAR)}  ${opt(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this.options.find((opt) => opt.value === this.value)!,
+            "selected"
+          )}`;
+        case "cancel":
+          return `${title}${color.gray(S_BAR)}  ${opt(
+            this.options[0],
+            "cancelled"
+          )}\n${color.gray(S_BAR)}`;
+        default: {
+          return `${title}${color.cyan(S_BAR)}  ${this.options
+            .map((option, i) =>
+              opt(option, i === this.cursor ? "active" : "inactive")
+            )
+            .join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
+        }
+      }
+    },
+  }).prompt() as Promise<Value | symbol>;
+};
+
+export interface MultiSelectOptions<Options extends Option<Value>[], Value> {
+  message: string;
+  options: Options;
+  initialValues?: Value[];
+  required?: boolean;
+  cursorAt?: Value;
+}
+export const multiselect = <Options extends Option<Value>[], Value>(
+  opts: MultiSelectOptions<Options, Value>
+) => {
+  const opt = (
+    option: Option<Value>,
+    state:
+      | "inactive"
+      | "active"
+      | "selected"
+      | "active-selected"
+      | "submitted"
+      | "cancelled"
+  ) => {
+    const label = option.label ?? String(option.value);
+    switch (state) {
+      case "active": {
+        return `${color.cyan(S_CHECKBOX_ACTIVE)} ${label} ${
+          option.hint ? color.dim(`(${option.hint})`) : ""
+        }`;
+      }
+      case "selected": {
+        return `${color.green(S_CHECKBOX_SELECTED)} ${color.dim(label)}`;
+      }
+      case "cancelled": {
+        return `${color.strikethrough(color.dim(label))}`;
+      }
+      case "active-selected": {
+        return `${color.green(S_CHECKBOX_SELECTED)} ${label} ${
+          option.hint ? color.dim(`(${option.hint})`) : ""
+        }`;
+      }
+      case "submitted": {
+        return `${color.dim(label)}`;
+      }
+      // No default
+    }
+    return `${color.dim(S_CHECKBOX_INACTIVE)} ${color.dim(label)}`;
+  };
+
+  return new MultiSelectPrompt({
+    options: opts.options,
+    initialValues: opts.initialValues,
+    required: opts.required ?? true,
+    cursorAt: opts.cursorAt,
+    validate(selected: Value[]) {
+      if (this.required && selected.length === 0) {
+        return `Please select at least one option.\n${color.reset(
+          color.dim(
+            `Press ${color.gray(
+              color.bgWhite(color.inverse(" space "))
+            )} to select, ${color.gray(
+              color.bgWhite(color.inverse(" enter "))
+            )} to submit`
+          )
+        )}`;
+      }
+    },
+    render() {
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+        opts.message
+      }\n`;
+
+      switch (this.state) {
+        case "submit": {
+          return `${title}${color.gray(S_BAR)}  ${
+            this.options
+              .filter(({ value }) => this.value.includes(value))
+              .map((option) => opt(option, "submitted"))
+              .join(color.dim(", ")) || color.dim("none")
+          }`;
+        }
+        case "cancel": {
+          const label = this.options
+            .filter(({ value }) => this.value.includes(value))
+            .map((option) => opt(option, "cancelled"))
+            .join(color.dim(", "));
+          return `${title}${color.gray(S_BAR)}  ${
+            label.trim() ? `${label}\n${color.gray(S_BAR)}` : ""
+          }`;
+        }
+        case "error": {
+          const footer = this.error
+            .split("\n")
+            .map((ln, i) =>
+              i === 0
+                ? `${color.yellow(S_BAR_END)}  ${color.yellow(ln)}`
+                : `   ${ln}`
+            )
+            .join("\n");
+          return (
+            title +
+            color.yellow(S_BAR) +
+            "  " +
+            this.options
+              .map((option, i) => {
+                const selected = this.value.includes(option.value);
+                const active = i === this.cursor;
+                if (active && selected) {
+                  return opt(option, "active-selected");
+                }
+                if (selected) {
+                  return opt(option, "selected");
+                }
+                return opt(option, active ? "active" : "inactive");
+              })
+              .join(`\n${color.yellow(S_BAR)}  `) +
+            "\n" +
+            footer +
+            "\n"
+          );
+        }
+        default: {
+          return `${title}${color.cyan(S_BAR)}  ${this.options
+            .map((option, i) => {
+              const selected = this.value.includes(option.value);
+              const active = i === this.cursor;
+              if (active && selected) {
+                return opt(option, "active-selected");
+              }
+              if (selected) {
+                return opt(option, "selected");
+              }
+              return opt(option, active ? "active" : "inactive");
+            })
+            .join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
+        }
+      }
+    },
+  }).prompt() as Promise<Value[] | symbol>;
+};
+
+export interface GroupMultiSelectOptions<
+  Options extends Option<Value>[],
+  Value
+> {
+  message: string;
+  options: Record<string, Options>;
+  initialValues?: Value[];
+  required?: boolean;
+  cursorAt?: Value;
+}
+export const groupMultiselect = <Options extends Option<Value>[], Value>(
+  opts: GroupMultiSelectOptions<Options, Value>
+) => {
+  const opt = (
+    option: Option<Value>,
+    state:
+      | "inactive"
+      | "active"
+      | "selected"
+      | "active-selected"
+      | "group-active"
+      | "group-active-selected"
+      | "submitted"
+      | "cancelled",
+    options: Option<Value>[] = []
+  ) => {
+    const label = option.label ?? String(option.value);
+    const isItem = typeof (option as any).group === "string";
+    const next =
+      isItem && (options[options.indexOf(option) + 1] ?? { group: true });
+    const isLast = isItem && (next as any).group === true;
+    const prefix = isItem ? `${isLast ? S_BAR_END : S_BAR} ` : "";
+
+    switch (state) {
+      case "active": {
+        return `${color.dim(prefix)}${color.cyan(S_CHECKBOX_ACTIVE)} ${label} ${
+          option.hint ? color.dim(`(${option.hint})`) : ""
+        }`;
+      }
+      case "group-active": {
+        return `${prefix}${color.cyan(S_CHECKBOX_ACTIVE)} ${color.dim(label)}`;
+      }
+      case "group-active-selected": {
+        return `${prefix}${color.green(S_CHECKBOX_SELECTED)} ${color.dim(
+          label
+        )}`;
+      }
+      case "selected": {
+        return `${color.dim(prefix)}${color.green(
+          S_CHECKBOX_SELECTED
+        )} ${color.dim(label)}`;
+      }
+      case "cancelled": {
+        return `${color.strikethrough(color.dim(label))}`;
+      }
+      case "active-selected": {
+        return `${color.dim(prefix)}${color.green(
+          S_CHECKBOX_SELECTED
+        )} ${label} ${option.hint ? color.dim(`(${option.hint})`) : ""}`;
+      }
+      case "submitted": {
+        return `${color.dim(label)}`;
+      }
+      // No default
+    }
+    return `${color.dim(prefix)}${color.dim(S_CHECKBOX_INACTIVE)} ${color.dim(
+      label
+    )}`;
+  };
+
+  return new GroupMultiSelectPrompt({
+    options: opts.options,
+    initialValues: opts.initialValues,
+    required: opts.required ?? true,
+    cursorAt: opts.cursorAt,
+    validate(selected: Value[]) {
+      if (this.required && selected.length === 0) {
+        return `Please select at least one option.\n${color.reset(
+          color.dim(
+            `Press ${color.gray(
+              color.bgWhite(color.inverse(" space "))
+            )} to select, ${color.gray(
+              color.bgWhite(color.inverse(" enter "))
+            )} to submit`
+          )
+        )}`;
+      }
+    },
+    render() {
+      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${
+        opts.message
+      }\n`;
+
+      switch (this.state) {
+        case "submit": {
+          return `${title}${color.gray(S_BAR)}  ${this.options
+            .filter(({ value }) => this.value.includes(value))
+            .map((option) => opt(option, "submitted"))
+            .join(color.dim(", "))}`;
+        }
+        case "cancel": {
+          const label = this.options
+            .filter(({ value }) => this.value.includes(value))
+            .map((option) => opt(option, "cancelled"))
+            .join(color.dim(", "));
+          return `${title}${color.gray(S_BAR)}  ${
+            label.trim() ? `${label}\n${color.gray(S_BAR)}` : ""
+          }`;
+        }
+        case "error": {
+          const footer = this.error
+            .split("\n")
+            .map((ln, i) =>
+              i === 0
+                ? `${color.yellow(S_BAR_END)}  ${color.yellow(ln)}`
+                : `   ${ln}`
+            )
+            .join("\n");
+          return `${title}${color.yellow(S_BAR)}  ${this.options
+            .map((option, i, options) => {
+              const selected =
+                this.value.includes(option.value) ||
+                (option.group === true &&
+                  this.isGroupSelected(`${option.value}`));
+              const active = i === this.cursor;
+              const groupActive =
+                !active &&
+                typeof option.group === "string" &&
+                this.options[this.cursor].value === option.group;
+              if (groupActive) {
+                return opt(
+                  option,
+                  selected ? "group-active-selected" : "group-active",
+                  options
+                );
+              }
+              if (active && selected) {
+                return opt(option, "active-selected", options);
+              }
+              if (selected) {
+                return opt(option, "selected", options);
+              }
+              return opt(option, active ? "active" : "inactive", options);
+            })
+            .join(`\n${color.yellow(S_BAR)}  `)}\n${footer}\n`;
+        }
+        default: {
+          return `${title}${color.cyan(S_BAR)}  ${this.options
+            .map((option, i, options) => {
+              const selected =
+                this.value.includes(option.value) ||
+                (option.group === true &&
+                  this.isGroupSelected(`${option.value}`));
+              const active = i === this.cursor;
+              const groupActive =
+                !active &&
+                typeof option.group === "string" &&
+                this.options[this.cursor].value === option.group;
+              if (groupActive) {
+                return opt(
+                  option,
+                  selected ? "group-active-selected" : "group-active",
+                  options
+                );
+              }
+              if (active && selected) {
+                return opt(option, "active-selected", options);
+              }
+              if (selected) {
+                return opt(option, "selected", options);
+              }
+              return opt(option, active ? "active" : "inactive", options);
+            })
+            .join(`\n${color.cyan(S_BAR)}  `)}\n${color.cyan(S_BAR_END)}\n`;
+        }
+      }
+    },
+  }).prompt() as Promise<Value[] | symbol>;
+};
+
+const strip = (str: string) => str.replace(ansiRegex(), "");
+export const note = (message = "", title = "") => {
+  const lines = `\n${message}\n`.split("\n");
+  const len =
+    Math.max(
+      // eslint-disable-next-line unicorn/no-array-reduce
+      lines.reduce((sum, ln) => {
+        ln = strip(ln);
+        return ln.length > sum ? ln.length : sum;
+      }, 0),
+      strip(title).length
+    ) + 2;
+  const msg = lines
+    .map(
+      (ln) =>
+        `${color.gray(S_BAR)}  ${color.dim(ln)}${" ".repeat(
+          len - strip(ln).length
+        )}${color.gray(S_BAR)}`
+    )
+    .join("\n");
+  process.stdout.write(
+    `${color.gray(S_BAR)}\n${color.green(S_STEP_SUBMIT)}  ${color.reset(
+      title
+    )} ${color.gray(
+      S_BAR_H.repeat(Math.max(len - title.length - 1, 1)) + S_CORNER_TOP_RIGHT
+    )}\n${msg}\n${color.gray(
+      S_CONNECT_LEFT + S_BAR_H.repeat(len + 2) + S_CORNER_BOTTOM_RIGHT
+    )}\n`
+  );
+};
+
+export const cancel = (message = "") => {
+  process.stdout.write(`${color.gray(S_BAR_END)}  ${color.red(message)}\n\n`);
+};
+
+export const intro = (title = "") => {
+  process.stdout.write(`${color.gray(S_BAR_START)}  ${title}\n`);
+};
+
+export const outro = (message = "") => {
+  process.stdout.write(
+    `${color.gray(S_BAR)}\n${color.gray(S_BAR_END)}  ${message}\n\n`
+  );
+};
+
+export type LogMessageOptions = {
+  symbol?: string;
+};
+export const log = {
+  message: (
+    message = "",
+    { symbol = color.gray(S_BAR) }: LogMessageOptions = {}
+  ) => {
+    const parts = [`${color.gray(S_BAR)}`];
+    if (message) {
+      const [firstLine, ...lines] = message.split("\n");
+      parts.push(
+        `${symbol}  ${firstLine}`,
+        ...lines.map((ln) => `${color.gray(S_BAR)}  ${ln}`)
+      );
+    }
+    process.stdout.write(`${parts.join("\n")}\n`);
+  },
+  info: (message: string) => {
+    log.message(message, { symbol: color.blue(S_INFO) });
+  },
+  success: (message: string) => {
+    log.message(message, { symbol: color.green(S_SUCCESS) });
+  },
+  step: (message: string) => {
+    log.message(message, { symbol: color.green(S_STEP_SUBMIT) });
+  },
+  warn: (message: string) => {
+    log.message(message, { symbol: color.yellow(S_WARN) });
+  },
+  /** alias for `log.warn()`. */
+  warning: (message: string) => {
+    log.warn(message);
+  },
+  error: (message: string) => {
+    log.message(message, { symbol: color.red(S_ERROR) });
+  },
+};
+
+const frames = unicode ? ["◒", "◐", "◓", "◑"] : ["•", "o", "O", "0"];
+
+export const spinner = () => {
+  let unblock: () => void;
+  let loop: NodeJS.Timer;
+  const delay = unicode ? 80 : 120;
+  return {
+    start(message = "") {
+      message = message.replace(/\.?\.?\.$/, "");
+      unblock = block();
+      process.stdout.write(
+        `${color.gray(S_BAR)}\n${color.magenta("○")}  ${message}\n`
+      );
+      let i = 0;
+      let dot = 0;
+      loop = setInterval(() => {
+        const frame = frames[i];
+        process.stdout.write(cursor.move(-999, -1));
+        process.stdout.write(
+          `${color.magenta(frame)}  ${message}${
+            Math.floor(dot) >= 1 ? ".".repeat(Math.floor(dot)).slice(0, 3) : ""
+          }   \n`
+        );
+        i = i === frames.length - 1 ? 0 : i + 1;
+        dot = dot === frames.length ? 0 : dot + 0.125;
+      }, delay);
+    },
+    stop(message = "") {
+      process.stdout.write(cursor.move(-999, -2));
+      process.stdout.write(erase.down(2));
+      clearInterval(loop);
+      process.stdout.write(
+        `${color.gray(S_BAR)}\n${color.green(S_STEP_SUBMIT)}  ${message}\n`
+      );
+      unblock();
+    },
+  };
+};
+
+// Adapted from https://github.com/chalk/ansi-regex
+// @see LICENSE
+function ansiRegex() {
+  const pattern = [
+    "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
+    "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+  ].join("|");
+
+  return new RegExp(pattern, "g");
+}
+
+export type PromptGroupAwaitedReturn<T> = {
+  [P in keyof T]: Exclude<Awaited<T[P]>, symbol>;
+};
+
+export interface PromptGroupOptions<T> {
+  /**
+   * Control how the group can be canceled
+   * if one of the prompts is canceled.
+   */
+  onCancel?: (opts: {
+    results: Prettify<Partial<PromptGroupAwaitedReturn<T>>>;
+  }) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Prettify<T> = {} & {
+  [P in keyof T]: T[P];
+};
+
+export type PromptGroup<T> = {
+  [P in keyof T]: (opts: {
+    results: Prettify<Partial<PromptGroupAwaitedReturn<Omit<T, P>>>>;
+  }) => void | Promise<T[P] | void>;
+};
+
+/**
+ * Define a group of prompts to be displayed
+ * and return a results of objects within the group
+ */
+export const group = async <T>(
+  prompts: PromptGroup<T>,
+  opts?: PromptGroupOptions<T>
+): Promise<Prettify<PromptGroupAwaitedReturn<T>>> => {
+  const results = {} as any;
+  const promptNames = Object.keys(prompts);
+
+  for (const name of promptNames) {
+    const prompt = prompts[name as keyof T];
+    const result = await prompt({ results })?.catch((e) => {
+      throw e;
+    });
+
+    // Pass the results to the onCancel function
+    // so the user can decide what to do with the results
+    // TODO: Switch to callback within core to avoid isCancel Fn
+    if (typeof opts?.onCancel === "function" && isCancel(result)) {
+      results[name] = "canceled";
+      opts.onCancel({ results });
+      continue;
+    }
+
+    results[name] = result;
+  }
+
+  return results;
+};


### PR DESCRIPTION
Closes #169

Add support for `await consola.prompt` based on `@clak/core` and a themed version of `@clak/prompts`.

Browser build uses native `prompt`/`confirm`


