### PR TITLE
feat: `/basic`, `/core` and `/browser` subpath exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Will display in the terminal:
 
 <img width="760" alt="image" src="https://user-images.githubusercontent.com/5158436/231029244-abc79f48-ca16-4eaa-b592-7abd271ecb1f.png">
 
-Smaller core builds: (You can use base builds without fancy reporter to save ~1/5 of the bundle size)
+You can use smaller core builds without fancy reporter to save 80% of the bundle size:
 
 ```ts
 import { consola, createConsola } from "consola/basic";

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Will display in the terminal:
 
 <img width="760" alt="image" src="https://user-images.githubusercontent.com/5158436/231029244-abc79f48-ca16-4eaa-b592-7abd271ecb1f.png">
 
+Smaller core builds: (You can use base builds without fancy reporter to save ~1/5 of the bundle size)
+
+```ts
+import { consola, createConsola } from "consola/basic";
+import { consola, createConsola } from "consola/browser";
+import { createConsola } from "consola/core";
+```
+
 ## Methods
 
 #### `<type>(logObject)` `<type>(args...)`

--- a/basic.d.ts.ts
+++ b/basic.d.ts.ts
@@ -1,0 +1,1 @@
+export * from "./dist/index.basic";

--- a/browser.d.ts.ts
+++ b/browser.d.ts.ts
@@ -1,0 +1,1 @@
+export * from "./dist/index.browser";

--- a/core.d.ts
+++ b/core.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/index.core";

--- a/package.json
+++ b/package.json
@@ -30,14 +30,36 @@
         "types": "./dist/index.browser.d.ts",
         "import": "./dist/index.browser.mjs"
       }
+    },
+    "./browser": {
+      "types": "./dist/index.browser.d.ts",
+      "import": "./dist/index.browser.mjs"
+    },
+    "./basic": {
+      "node": {
+        "types": "./dist/index.basic.d.ts",
+        "import": "./dist/index.basic.mjs",
+        "require": "./dist/index.basic.cjs"
+      },
+      "default": {
+        "types": "./dist/index.browser.d.ts",
+        "import": "./dist/index.browser.mjs"
+      }
+    },
+    "./core": {
+      "types": "./dist/index.core.d.ts",
+      "import": "./dist/index.core.mjs",
+      "require": "./dist/index.core.cjs"
     }
   },
   "main": "./lib/index.cjs",
   "module": "./dist/index.mjs",
+  "browser": "./dist/index.browser.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "lib"
+    "lib",
+    "*.d.ts"
   ],
   "scripts": {
     "build": "unbuild",

--- a/src/consola.ts
+++ b/src/consola.ts
@@ -398,7 +398,7 @@ Consola.prototype.pause = Consola.prototype.pauseLogs;
 Consola.prototype.resume = Consola.prototype.resumeLogs;
 
 export function createConsola(
-  options: Partial<ConsolaOptions>
+  options: Partial<ConsolaOptions> = {}
 ): ConsolaInstance {
   return new Consola(options) as ConsolaInstance;
 }

--- a/src/index.basic.ts
+++ b/src/index.basic.ts
@@ -1,0 +1,32 @@
+import { LogLevels, LogLevel } from "./constants";
+import type { ConsolaOptions } from "./types";
+import { BasicReporter } from "./reporters/basic";
+import { ConsolaInstance, createConsola as _createConsola } from "./consola";
+
+export * from "./index.shared";
+
+export function createConsola(
+  options: Partial<ConsolaOptions & { fancy: boolean }> = {}
+): ConsolaInstance {
+  // Log level
+  let level: LogLevel = LogLevels.info;
+  if (process.env.CONSOLA_LEVEL) {
+    level = Number.parseInt(process.env.CONSOLA_LEVEL) ?? level;
+  }
+
+  // Create new consola instance
+  const consola = _createConsola({
+    level,
+    defaults: { level },
+    stdout: process.stdout,
+    stderr: process.stderr,
+    reporters: options.reporters || [new BasicReporter()],
+    ...options,
+  });
+
+  return consola;
+}
+
+export const consola = createConsola();
+
+export default consola;

--- a/src/index.core.ts
+++ b/src/index.core.ts
@@ -1,0 +1,2 @@
+export { createConsola } from "./consola";
+export * from "./index.shared";


### PR DESCRIPTION
Base build without fancy reporter, saves ~80% of the bundle size.