### PR TITLE
feat(fancy): underlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ consola.error(new Error("This is an example error. Everything is fine!"));
 await consola.prompt("Deploy to the production?", {
   type: "confirm",
 });
+
+// formatting with colorette
+consola.log("Text as `monospace` and _underline_ or `(underline,cyan)both`!")
 ```
 
 Will display in the terminal:

--- a/README.md
+++ b/README.md
@@ -59,9 +59,6 @@ consola.error(new Error("This is an example error. Everything is fine!"));
 await consola.prompt("Deploy to the production?", {
   type: "confirm",
 });
-
-// formatting with colorette
-consola.log("Text as `monospace` and _underline_ or `(underline,cyan)both`!")
 ```
 
 Will display in the terminal:

--- a/examples/special.ts
+++ b/examples/special.ts
@@ -20,10 +20,6 @@ consola.log("We can `monospace` keyword using grave accent charachter!");
 
 consola.log("We can also _underline_ words!");
 
-consola.log("We can also do `(bgGreen)special` highlight");
-
-consola.log("How about `(yellow,underline)chaining` them?");
-
 // Nonstandard error
 const { message, stack } = new Error("Custom Error!");
 consola.error({ message, stack });

--- a/examples/special.ts
+++ b/examples/special.ts
@@ -18,6 +18,8 @@ consola.error(undefined, null, false, true, Number.NaN);
 
 consola.log("We can `monospace` keyword using grave accent charachter!");
 
+consola.log("We can also _underline_ words!")
+
 // Nonstandard error
 const { message, stack } = new Error("Custom Error!");
 consola.error({ message, stack });

--- a/examples/special.ts
+++ b/examples/special.ts
@@ -18,7 +18,11 @@ consola.error(undefined, null, false, true, Number.NaN);
 
 consola.log("We can `monospace` keyword using grave accent charachter!");
 
-consola.log("We can also _underline_ words!")
+consola.log("We can also _underline_ words!");
+
+consola.log("We can also do `(bgGreen)special` highlight");
+
+consola.log("How about `(yellow,underline)chaining` them?");
 
 // Nonstandard error
 const { message, stack } = new Error("Custom Error!");

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -86,7 +86,7 @@ export class FancyReporter extends BasicReporter {
     const tag = logObj.tag ? colors.gray(logObj.tag) : "";
 
     let line;
-    const left = this.filterAndJoin([type, highlightBackticks(message)]);
+    const left = this.filterAndJoin([type, characterFormat(message)]);
     const right = this.filterAndJoin(opts.columns ? [tag, coloredDate] : [tag]);
     const space =
       (opts.columns || 0) - stringWidth(left) - stringWidth(right) - 2;
@@ -96,7 +96,7 @@ export class FancyReporter extends BasicReporter {
         ? left + " ".repeat(space) + right
         : (right ? `${colors.gray(`[${right}]`)} ` : "") + left;
 
-    line += highlightBackticks(
+    line += characterFormat(
       additional.length > 0 ? "\n" + additional.join("\n") : ""
     );
 
@@ -109,8 +109,12 @@ export class FancyReporter extends BasicReporter {
   }
 }
 
-function highlightBackticks(str: string) {
-  return str.replace(/`([^`]+)`/gm, (_, m) => colors.cyan(m));
+function characterFormat(str: string) {
+  return str
+    // highlight backticks
+    .replace(/`([^`]+)`/gm, (_, m) => colors.cyan(m))
+    // underline underscores
+    .replace(/_([^_]+)_/gm, (_, m) => colors.underline(m));
 }
 
 function getColor(color = "white") {

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -112,10 +112,6 @@ export class FancyReporter extends BasicReporter {
 function characterFormat(str: string) {
   return (
     str
-      .replace(/`\(([^)]*)\)([^`]+)`/gm, (_, f, m) =>
-        // eslint-disable-next-line unicorn/no-array-reduce
-        f.split(',').reduce((p: string, c: string) => getColor(c)(p), m)
-      )
       // highlight backticks
       .replace(/`([^`]+)`/gm, (_, m) => colors.cyan(m))
       // underline underscores

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -110,13 +110,17 @@ export class FancyReporter extends BasicReporter {
 }
 
 function characterFormat(str: string) {
-  return str
-    // eslint-disable-next-line unicorn/no-array-reduce
-    .replace(/`\(([^)]*)\)([^`]+)`/gm, (_, f, m) => f.split(',').reduce((p: string, c: string) => getColor(c)(p), m))
-    // highlight backticks
-    .replace(/`([^`]+)`/gm, (_, m) => colors.cyan(m))
-    // underline underscores
-    .replace(/_([^_]+)_/gm, (_, m) => colors.underline(m));
+  return (
+    str
+      .replace(/`\(([^)]*)\)([^`]+)`/gm, (_, f, m) =>
+        // eslint-disable-next-line unicorn/no-array-reduce
+        f.split(',').reduce((p: string, c: string) => getColor(c)(p), m)
+      )
+      // highlight backticks
+      .replace(/`([^`]+)`/gm, (_, m) => colors.cyan(m))
+      // underline underscores
+      .replace(/_([^_]+)_/gm, (_, m) => colors.underline(m))
+  );
 }
 
 function getColor(color = "white") {

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -111,6 +111,8 @@ export class FancyReporter extends BasicReporter {
 
 function characterFormat(str: string) {
   return str
+    // eslint-disable-next-line unicorn/no-array-reduce
+    .replace(/`\(([^)]*)\)([^`]+)`/gm, (_, f, m) => f.split(',').reduce((p: string, c: string) => getColor(c)(p), m))
     // highlight backticks
     .replace(/`([^`]+)`/gm, (_, m) => colors.cyan(m))
     // underline underscores


### PR DESCRIPTION
Similar to highlighting backticks, this adds functionality to underline.

Renamed `highlightBackticks` to `characterFormat` to chain the formatting. 🙂 

Preview (based on `examples/special.ts`):
![image](https://github.com/unjs/consola/assets/56732164/06c767c8-0fb4-46b2-966e-06317ea77fc6)

Update: added special format syntax as well (really need this feature!)

![image](https://github.com/unjs/consola/assets/56732164/83081fe0-20a3-4bdc-8c70-65be49f5cb8b)

