### PR TITLE
feat: box util function

### DIFF
--- a/examples/box.ts
+++ b/examples/box.ts
@@ -1,0 +1,31 @@
+import { cyanBright } from "colorette";
+import { consola } from "./utils";
+
+async function main() {
+  await consola.box(`I am the default box`);
+
+  await consola.box(`I am a box with different options`, {
+    title: "Box with options",
+    padding: 1,
+    border: {
+      color: "magenta",
+      style: "double-single-rounded",
+    },
+  });
+
+  await consola.box(
+    `${cyanBright("v1.0.2")} → ${cyanBright(
+      "v2.0.2"
+    )}.\n\nRun "npm install -g consola" to update`,
+    {
+      title: "Update available!",
+      padding: 2,
+      border: {
+        color: "yellow",
+        style: "rounded",
+      },
+    }
+  );
+}
+
+main();

--- a/src/box.ts
+++ b/src/box.ts
@@ -1,0 +1,9 @@
+import { boxy } from "./utils/box";
+import type { BoxyOpts } from "./utils/box";
+
+export default async function box(
+  title: string,
+  opts?: BoxyOpts
+): Promise<void> {
+  console.log(await boxy(title, opts));
+}

--- a/src/consola.ts
+++ b/src/consola.ts
@@ -8,6 +8,7 @@ import type {
   ConsolaOptions,
 } from "./types";
 import type { PromptOptions } from "./prompt";
+import type { BoxyOpts } from "./utils/box";
 
 let paused = false;
 const queue: any[] = [];
@@ -90,6 +91,13 @@ export class Consola {
       throw new Error("prompt is not supported!");
     }
     return this.options.prompt<any, any, T>(message, opts);
+  }
+
+  box(text: string, opts?: BoxyOpts) {
+    if (!this.options.box) {
+      throw new Error("box is not supported!");
+    }
+    return this.options.box(text, opts);
   }
 
   create(options: Partial<ConsolaOptions>): ConsolaInstance {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import type { ConsolaOptions } from "./types";
 import { BasicReporter } from "./reporters/basic";
 import { FancyReporter } from "./reporters/fancy";
 import { ConsolaInstance, createConsola as _createConsola } from "./consola";
-
 export * from "./index.shared";
 
 export function createConsola(
@@ -23,6 +22,7 @@ export function createConsola(
     stdout: process.stdout,
     stderr: process.stderr,
     prompt: (...args) => import("./prompt").then((m) => m.prompt(...args)),
+    box: (...args) => import("./box").then((m) => m.default(...args)),
     reporters: options.reporters || [
       options.fancy ?? !(isCI || isTest)
         ? new FancyReporter()

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface ConsolaOptions {
   stderr?: NodeJS.WriteStream;
   mockFn?: (type: LogType, defaults: InputLogObject) => (...args: any) => void;
   prompt?: typeof import("./prompt").prompt | undefined;
+  box?: typeof import("./box").default | undefined;
   formatOptions: FormatOptions;
 }
 

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -74,7 +74,7 @@ const roundedPreset: BoxyBorderStyle = {
   v: "│",
 };
 
-const singlePreset: BoxyBorderStyle = {
+const singleThickPreset: BoxyBorderStyle = {
   tl: "┏",
   tr: "┓",
   bl: "┗",
@@ -124,7 +124,7 @@ const stylePreset = {
   double: doublePreset,
   "double-single": doubleSinglePreset,
   "double-single-rounded": doubleSingleRoundedPreset,
-  single: singlePreset,
+  "single-thick": singleThickPreset,
   "single-double": singleDoublePreset,
   "single-double-rounded": singleDoubleRoundedPreset,
   rounded: roundedPreset,
@@ -167,7 +167,7 @@ export interface BoxyOpts {
      * }
      * ```
      */
-    style?: BoxyBorderStyle | keyof typeof stylePreset | "random";
+    style?: BoxyBorderStyle | keyof typeof stylePreset;
   };
   /**
    * The vertical alignment of the text
@@ -186,12 +186,6 @@ export interface BoxyOpts {
    */
   padding?: number;
 }
-
-const randomPreset = () => {
-  const keys = Object.keys(stylePreset);
-  const randomKey = keys[Math.floor(Math.random() * keys.length)];
-  return stylePreset[randomKey as keyof typeof stylePreset];
-};
 
 export const boxy = async (text: string, opts?: BoxyOpts) => {
   const defaultOpts = defu(opts || {}, {
@@ -216,9 +210,7 @@ export const boxy = async (text: string, opts?: BoxyOpts) => {
   // Get the characters for the box
   const presetChars =
     typeof border.style === "string"
-      ? border.style === "random"
-        ? randomPreset()
-        : stylePreset[border.style as keyof typeof stylePreset]
+      ? stylePreset[border.style as keyof typeof stylePreset]
       : border.style;
 
   // Set the color of the border

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,0 +1,280 @@
+import { defu } from "defu";
+import type { Colorette } from "colorette";
+import { stripAnsi } from "./string";
+
+export interface BoxyBorderStyle {
+  /**
+   * Top left corner
+   * @example `┌`
+   * @example `╔`
+   * @example `╓`
+   */
+  tl: string;
+  /**
+   * Top right corner
+   * @example `┐`
+   * @example `╗`
+   * @example `╖`
+   */
+  tr: string;
+  /**
+   * Bottom left corner
+   * @example `└`
+   * @example `╚`
+   * @example `╙`
+   */
+  bl: string;
+  /**
+   * Bottom right corner
+   * @example `┘`
+   * @example `╝`
+   * @example `╜`
+   */
+  br: string;
+  /**
+   * Horizontal line
+   * @example `─`
+   * @example `═`
+   * @example `─`
+   */
+  h: string;
+  /**
+   * Vertical line
+   * @example `│`
+   * @example `║`
+   * @example `║`
+   */
+  v: string;
+}
+
+const solidPreset: BoxyBorderStyle = {
+  tl: "┌",
+  tr: "┐",
+  bl: "└",
+  br: "┘",
+  h: "─",
+  v: "│",
+};
+
+const doublePreset: BoxyBorderStyle = {
+  tl: "╔",
+  tr: "╗",
+  bl: "╚",
+  br: "╝",
+  h: "═",
+  v: "║",
+};
+
+const roundedPreset: BoxyBorderStyle = {
+  tl: "╭",
+  tr: "╮",
+  bl: "╰",
+  br: "╯",
+  h: "─",
+  v: "│",
+};
+
+const singlePreset: BoxyBorderStyle = {
+  tl: "┏",
+  tr: "┓",
+  bl: "┗",
+  br: "┛",
+  h: "━",
+  v: "┃",
+};
+
+const doubleSinglePreset: BoxyBorderStyle = {
+  tl: "╓",
+  tr: "╖",
+  bl: "╙",
+  br: "╜",
+  h: "─",
+  v: "║",
+};
+
+const singleDoublePreset: BoxyBorderStyle = {
+  tl: "╒",
+  tr: "╕",
+  bl: "╘",
+  br: "╛",
+  h: "═",
+  v: "│",
+};
+
+const doubleSingleRoundedPreset: BoxyBorderStyle = {
+  tl: "╭",
+  tr: "╮",
+  bl: "╰",
+  br: "╯",
+  h: "─",
+  v: "║",
+};
+
+const singleDoubleRoundedPreset: BoxyBorderStyle = {
+  tl: "╭",
+  tr: "╮",
+  bl: "╰",
+  br: "╯",
+  h: "═",
+  v: "│",
+};
+
+const stylePreset = {
+  solid: solidPreset,
+  double: doublePreset,
+  "double-single": doubleSinglePreset,
+  "double-single-rounded": doubleSingleRoundedPreset,
+  single: singlePreset,
+  "single-double": singleDoublePreset,
+  "single-double-rounded": singleDoubleRoundedPreset,
+  rounded: roundedPreset,
+};
+
+export interface BoxyOpts {
+  /**
+   * The border options of the box
+   */
+  border?: {
+    /**
+     * The border color
+     * @default 'white'
+     */
+    color?: Exclude<
+      keyof Colorette,
+      | `bg${string}`
+      | "italic"
+      | "underline"
+      | "inverse"
+      | "hidden"
+      | "strikethrough"
+      | "bold"
+      | "dim"
+      | "reset"
+    >;
+    /**
+     * The border style
+     * @default 'solid'
+     * @example 'single-double-rounded'
+     * @example
+     * ```ts
+     * {
+     *   tl: '┌',
+     *   tr: '┐',
+     *   bl: '└',
+     *   br: '┘',
+     *   h: '─',
+     *   v: '│',
+     * }
+     * ```
+     */
+    style?: BoxyBorderStyle | keyof typeof stylePreset | "random";
+  };
+  /**
+   * The vertical alignment of the text
+   * @default 'center'
+   */
+  valign?: "top" | "center" | "bottom";
+  /**
+   * Title that will be displayed on top of the box
+   * @example 'Hello World'
+   * @example 'Hello {name}'
+   */
+  title?: string;
+  /**
+   * The padding of the box
+   * @default 2
+   */
+  padding?: number;
+}
+
+const randomPreset = () => {
+  const keys = Object.keys(stylePreset);
+  const randomKey = keys[Math.floor(Math.random() * keys.length)];
+  return stylePreset[randomKey as keyof typeof stylePreset];
+};
+
+export const boxy = async (text: string, opts?: BoxyOpts) => {
+  const defaultOpts = defu(opts || {}, {
+    title: undefined,
+    border: {
+      color: "white",
+      style: "solid",
+    },
+    valign: "center",
+    padding: 2,
+  });
+
+  const title = defaultOpts.title ? ` ${defaultOpts.title} ` : undefined;
+  const { border, valign, padding } = defaultOpts;
+
+  // Create the box
+  const box = [];
+
+  // Split the text into lines
+  const lines = text.split("\n");
+
+  // Get the characters for the box
+  const presetChars =
+    typeof border.style === "string"
+      ? border.style === "random"
+        ? randomPreset()
+        : stylePreset[border.style as keyof typeof stylePreset]
+      : border.style;
+
+  // Set the color of the border
+  const colorette = await import("colorette");
+  for (const key in presetChars) {
+    presetChars[key as keyof typeof presetChars] = colorette[
+      border.color as keyof Colorette
+    ](presetChars[key as keyof typeof presetChars]);
+  }
+
+  const paddingOffset = padding % 2 === 0 ? padding : padding + 1;
+  const height = lines.length + paddingOffset;
+  const width = Math.max(...lines.map((line) => line.length)) + paddingOffset;
+  const widthOffset = width + paddingOffset;
+
+  // Top line
+  // Include the title if it exists with borders
+  if (title) {
+    const left = presetChars.h.repeat(
+      Math.floor((width - stripAnsi(title).length) / 2)
+    );
+    const right = presetChars.h.repeat(
+      width - stripAnsi(title).length - stripAnsi(left).length + paddingOffset
+    );
+    box.push(`${presetChars.tl}${left}${title}${right}${presetChars.tr}`);
+  } else {
+    box.push(
+      `${presetChars.tl}${presetChars.h.repeat(widthOffset)}${presetChars.tr}`
+    );
+  }
+
+  // Middle lines
+  const valignOffset =
+    valign === "center"
+      ? Math.floor((height - lines.length) / 2)
+      : valign === "top"
+      ? height - lines.length - paddingOffset
+      : height - lines.length;
+
+  for (let i = 0; i < height; i++) {
+    if (i < valignOffset || i >= valignOffset + lines.length) {
+      // Empty line
+      box.push(`${presetChars.v}${" ".repeat(widthOffset)}${presetChars.v}`);
+    } else {
+      // Text line
+      const line = lines[i - valignOffset];
+      const left = " ".repeat(paddingOffset);
+      const right = " ".repeat(width - stripAnsi(line).length);
+      box.push(`${presetChars.v}${left}${line}${right}${presetChars.v}`);
+    }
+  }
+
+  // Bottom line
+  box.push(
+    `${presetChars.bl}${presetChars.h.repeat(widthOffset)}${presetChars.br}`
+  );
+
+  return box.join("\n");
+};

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,11 @@
+const ansiRegex = [
+  "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
+  "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+].join("|");
+
+export const stripAnsi = (text: string) =>
+  text.replace(new RegExp(ansiRegex, "g"), "");
+
 export function centerAlign(str: string, len: number, space = " ") {
   const free = len - str.length;
   if (free <= 0) {


### PR DESCRIPTION
# Context 

Reference: https://github.com/unjs/citty/pull/21

In this PR I will introduce a new util function for creating a box kinda like `boxen` but without deps! This was initially created for `unjs/citty` but now moved to `consola`. Thanks @pi0 for the idea.

The functionality is less than `boxen` but will get the job done for now and we make it better eventually!  

- Border presets includes: `solid`, `double`,  `double-single`, `double-single-rounded`, `single-thick`, `single-double`, `single-double-rounded` & `rounded`.
- Implements `colorette` to style the border while dynamically importing it to style it.

```ts
// API
await consola.box("You have an update!", {
  title: "Update available!",
  padding: 2,
  valign: 'center',
  border: {
    color: "yellow",
    style: "rounded",
  },
})
```

Preview: 

<img width="497" alt="image" src="https://github.com/unjs/consola/assets/6619884/d0fd77a5-e017-4a40-9c82-9cba18ef5b4b">

Thanks,
CP 🚀 
 