### PR TITLE
feat: color utils

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,7 +22,7 @@ SOFTWARE.
 
 ---
 
-Prompt support is based on https://github.com/natemoo-re/clack/
+Prompt support is based on https://github.com/natemoo-re/clack
 
 MIT License
 
@@ -33,3 +33,15 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Color support is based on https://github.com/jorgebucaran/colorette
+
+Copyright © Jorge Bucaran <https://jorgebucaran.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ import {
   leftAlign,
   align,
   box,
+  colors,
+  getColor,
+  colorize,
 } from "consola/utils";
 
 // CommonJS

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "@types/node": "^20.3.2",
     "@vitest/coverage-v8": "^0.32.2",
     "changelogen": "^0.5.3",
-    "colorette": "^2.0.20",
     "defu": "^6.1.2",
     "eslint": "^8.43.0",
     "eslint-config-unjs": "^0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ devDependencies:
   changelogen:
     specifier: ^0.5.3
     version: 0.5.3
-  colorette:
-    specifier: ^2.0.20
-    version: 2.0.20
   defu:
     specifier: ^6.1.2
     version: 6.1.2

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -1,6 +1,6 @@
 import stringWidth from "string-width";
 import isUnicodeSupported from "is-unicode-supported";
-import * as colors from "colorette";
+import { colors } from "../utils/color";
 import { parseStack } from "../utils/error";
 import { FormatOptions, LogObject } from "../types";
 import { LogLevel, LogType } from "../constants";
@@ -79,12 +79,12 @@ export class FancyReporter extends BasicReporter {
 
     if (logObj.type === "box") {
       return box(
-        highlightBackticks(
+        characterFormat(
           message + (additional.length > 0 ? "\n" + additional.join("\n") : "")
         ),
         {
           title: logObj.title
-            ? highlightBackticks(logObj.title as string)
+            ? characterFormat(logObj.title as string)
             : undefined,
           style: logObj.style as BoxOpts["style"],
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 export * from "./utils/box";
-
+export * from "./utils/color";
 export {
   stripAnsi,
   centerAlign,

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,4 +1,4 @@
-import * as colorette from "colorette";
+import { getColor } from "./color";
 import { stripAnsi } from "./string";
 
 export type BoxBorderStyle = {
@@ -226,8 +226,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
   const boxLines = [];
 
   // Get the characters for the box and colorize
-  const _color: (text: string) => string =
-    (colorette as any)[opts.style.borderColor] || ((text: string) => text);
+  const _color = getColor(opts.style.borderColor);
   const borderStyle = {
     ...(typeof opts.style.borderStyle === "string"
       ? boxStylePresets[

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,138 @@
+/**
+ * Based on https://github.com/jorgebucaran/colorette
+ * Read LICENSE file for more information
+ * https://github.com/jorgebucaran/colorette/blob/20fc196d07d0f87c61e0256eadd7831c79b24108/index.js
+ */
+
+import * as tty from "node:tty";
+
+// TODO: Migrate to std-env
+const {
+  env = {},
+  argv = [],
+  platform = "",
+} = typeof process === "undefined" ? {} : process;
+const isDisabled = "NO_COLOR" in env || argv.includes("--no-color");
+const isForced = "FORCE_COLOR" in env || argv.includes("--color");
+const isWindows = platform === "win32";
+const isDumbTerminal = env.TERM === "dumb";
+const isCompatibleTerminal =
+  tty && tty.isatty && tty.isatty(1) && env.TERM && !isDumbTerminal;
+const isCI =
+  "CI" in env &&
+  ("GITHUB_ACTIONS" in env || "GITLAB_CI" in env || "CIRCLECI" in env);
+const isColorSupported =
+  !isDisabled &&
+  (isForced || (isWindows && !isDumbTerminal) || isCompatibleTerminal || isCI);
+
+function replaceClose(
+  index: number,
+  string: string,
+  close: string,
+  replace: string,
+  head = string.slice(0, Math.max(0, index)) + replace,
+  tail = string.slice(Math.max(0, index + close.length)),
+  next = tail.indexOf(close)
+): string {
+  return head + (next < 0 ? tail : replaceClose(next, tail, close, replace));
+}
+
+function clearBleed(
+  index: number,
+  string: string,
+  open: string,
+  close: string,
+  replace: string
+) {
+  return index < 0
+    ? open + string + close
+    : open + replaceClose(index, string, close, replace) + close;
+}
+
+function filterEmpty(
+  open: string,
+  close: string,
+  replace = open,
+  at = open.length + 1
+) {
+  return (string: string) =>
+    string || !(string === "" || string === undefined)
+      ? clearBleed(
+          ("" + string).indexOf(close, at),
+          string,
+          open,
+          close,
+          replace
+        )
+      : "";
+}
+
+function init(open: number, close: number, replace?: string) {
+  return filterEmpty(`\u001B[${open}m`, `\u001B[${close}m`, replace);
+}
+
+const colorDefs = {
+  reset: init(0, 0),
+  bold: init(1, 22, "\u001B[22m\u001B[1m"),
+  dim: init(2, 22, "\u001B[22m\u001B[2m"),
+  italic: init(3, 23),
+  underline: init(4, 24),
+  inverse: init(7, 27),
+  hidden: init(8, 28),
+  strikethrough: init(9, 29),
+  black: init(30, 39),
+  red: init(31, 39),
+  green: init(32, 39),
+  yellow: init(33, 39),
+  blue: init(34, 39),
+  magenta: init(35, 39),
+  cyan: init(36, 39),
+  white: init(37, 39),
+  gray: init(90, 39),
+  bgBlack: init(40, 49),
+  bgRed: init(41, 49),
+  bgGreen: init(42, 49),
+  bgYellow: init(43, 49),
+  bgBlue: init(44, 49),
+  bgMagenta: init(45, 49),
+  bgCyan: init(46, 49),
+  bgWhite: init(47, 49),
+  blackBright: init(90, 39),
+  redBright: init(91, 39),
+  greenBright: init(92, 39),
+  yellowBright: init(93, 39),
+  blueBright: init(94, 39),
+  magentaBright: init(95, 39),
+  cyanBright: init(96, 39),
+  whiteBright: init(97, 39),
+  bgBlackBright: init(100, 49),
+  bgRedBright: init(101, 49),
+  bgGreenBright: init(102, 49),
+  bgYellowBright: init(103, 49),
+  bgBlueBright: init(104, 49),
+  bgMagentaBright: init(105, 49),
+  bgCyanBright: init(106, 49),
+  bgWhiteBright: init(107, 49),
+};
+
+export type ColorName = keyof typeof colorDefs;
+export type ColorFunction = (text: string | number) => string;
+
+function createColors(useColor = isColorSupported) {
+  return useColor
+    ? colorDefs
+    : Object.fromEntries(Object.keys(colorDefs).map((key) => [key, String]));
+}
+
+export const colors = createColors() as Record<ColorName, ColorFunction>;
+
+export function getColor(
+  color: ColorName,
+  fallback: ColorName = "reset"
+): ColorFunction {
+  return colors[color] || colors[fallback];
+}
+
+export function colorize(color: ColorName, text: string | number): string {
+  return getColor(color)(text);
+}

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,8 +1,7 @@
 /**
- * Based on @clak/propmts (MIT - Copyright (c) Nate Moore - Check LICENSE)
+ * Based on https://github.com/natemoo-re/clack
+ * Read LICENSE file for more information
  * https://github.com/natemoo-re/clack/blob/593f93d06c1a53c8424e9aaf0c1c63fbf6975527/packages/prompts/src/index.ts
- *
- * Forked to use custom symbols and colors
  */
 
 import {
@@ -20,9 +19,9 @@ import {
 
 import isUnicodeSupported from "is-unicode-supported";
 
-import * as color from "colorette";
-
 import { cursor, erase } from "sisteransi";
+
+import { colors as color } from "./color";
 
 export { isCancel } from "@clack/core";
 


### PR DESCRIPTION
Export color utils from `consola/utils` subpath:

- `colors[name]`
- `getColor(name)`
- `colorize(name, text)`

Implementation is based on [colorette](https://github.com/jorgebucaran/colorette) which was already being used to make some small tweaks and generate types from the source. (Thanks @jorgebucaran and contribs for this amazing lib ❤️ )

Also thanks @antfu for original idea in #166
