### PR TITLE
fix(box): fix preset naming for `singleThick`

### DIFF
--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -79,7 +79,7 @@ const boxStylePresets: Record<string, BoxBorderStyle> = {
     h: "─",
     v: "║",
   },
-  SingleThick: {
+  singleThick: {
     tl: "┏",
     tr: "┓",
     bl: "┗",


### PR DESCRIPTION
@pi0 the naming seemed to be off so I just wanted to make a simple PR to fix it. 

Thanks,
CP 🚀 