### PR TITLE
chore: remove extra `await` in `spinner` example

### DIFF
--- a/examples/spinner.ts
+++ b/examples/spinner.ts
@@ -1,9 +1,9 @@
 import { consola } from "./utils";
 
 async function main() {
-  await consola.start("Creating project...");
+  consola.start("Creating project...");
   await new Promise((resolve) => setTimeout(resolve, 1000));
-  await consola.success("Project created!");
+  consola.success("Project created!");
 }
 
 main();


### PR DESCRIPTION
`start` or `success` does not return a promise.