### PR TITLE
fix: use `initial` in `select` and `multiselect` prompts

### DIFF
--- a/examples/prompt.ts
+++ b/examples/prompt.ts
@@ -13,10 +13,11 @@ async function main() {
   const projectType = await consola.prompt("Pick a project type.", {
     type: "select",
     options: [
-      "TypeScript",
+      "JavaScript",
       "TypeScript",
       { label: "CoffeeScript", value: "CoffeeScript", hint: "oh no" },
     ],
+    initial: "TypeScript",
   });
 
   const tools = await consola.prompt("Select additional tools.", {
@@ -27,6 +28,7 @@ async function main() {
       { value: "prettier", label: "Prettier" },
       { value: "gh-action", label: "GitHub Action" },
     ],
+    initial: ["eslint", "prettier"],
   });
 
   consola.start("Creating project...");

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -26,8 +26,8 @@ export type SelectOptions = {
 
 export type MultiSelectOptions = {
   type: "multiselect";
-  initial?: string;
-  options: string[] | SelectOption[];
+  initial?: string[];
+  options: (string | SelectOption)[];
   required?: boolean;
 };
 
@@ -77,6 +77,7 @@ export async function prompt<
       options: opts.options.map((o) =>
         typeof o === "string" ? { value: o, label: o } : o,
       ),
+      initialValue: opts.initial,
     })) as any;
   }
 
@@ -87,6 +88,7 @@ export async function prompt<
         typeof o === "string" ? { value: o, label: o } : o,
       ),
       required: opts.required,
+      initialValues: opts.initial,
     })) as any;
   }
 

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -748,7 +748,7 @@ const frames = unicode ? ["◒", "◐", "◓", "◑"] : ["•", "o", "O", "0"];
 
 export const spinner = () => {
   let unblock: () => void;
-  let loop: NodeJS.Timer;
+  let loop: NodeJS.Timeout;
   const delay = unicode ? 80 : 120;
   return {
     start(message = "") {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`SelectPrompt` and `MultiSelectPrompt` of `@clack/core` support `initialValue` option. In [utils](https://github.com/unjs/consola/blob/main/src/utils/prompt.ts) file this option is used, but in [prompt](https://github.com/unjs/consola/blob/main/src/prompt.ts) file `initial` option is not passed to `initialValue`/`initialValues` options

This pull request fixes that problem

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
