### PR TITLE
feat: support report error `cause`

### DIFF
--- a/examples/error.ts
+++ b/examples/error.ts
@@ -1,0 +1,13 @@
+import { consola } from "./utils";
+
+const error = new Error("This is an error", {
+  cause: new Error("This is the cause", {
+    cause: new Error("This is the cause of the cause"),
+  }),
+});
+
+console.error(error);
+
+console.log("\n");
+
+consola.error(error);

--- a/src/reporters/basic.ts
+++ b/src/reporters/basic.ts
@@ -12,18 +12,21 @@ const bracket = (x: string) => (x ? `[${x}]` : "");
 
 export class BasicReporter implements ConsolaReporter {
   formatStack(stack: string, opts: FormatOptions) {
-    return "  " + parseStack(stack).join("\n  ");
+    const indent = "  ".repeat((opts?.errorLevel || 0) + 1);
+    return indent + parseStack(stack).join(`\n${indent}`);
   }
 
   formatError(err: any, opts: FormatOptions): string {
-    const { isCausedError = false } = opts;
-    const prefix = isCausedError ? "Caused by: " : "";
     const message = err.message ?? formatWithOptions(opts, err);
     const stack = err.stack ? this.formatStack(err.stack, opts) : "";
+
+    const level = opts?.errorLevel || 0;
+    const causedPrefix = level > 0 ? `${"  ".repeat(level)}[cause]: ` : "";
     const causedError = err.cause
-      ? "\n\n" + this.formatError(err.cause, { ...opts, isCausedError: true })
+      ? "\n\n" + this.formatError(err.cause, { ...opts, errorLevel: level + 1 })
       : "";
-    return prefix + message + "\n" + stack + causedError;
+
+    return causedPrefix + message + "\n" + stack + causedError;
   }
 
   formatArgs(args: any[], opts: FormatOptions) {

--- a/src/reporters/basic.ts
+++ b/src/reporters/basic.ts
@@ -15,10 +15,21 @@ export class BasicReporter implements ConsolaReporter {
     return "  " + parseStack(stack).join("\n  ");
   }
 
+  formatError(err: any, opts: FormatOptions): string {
+    const { isCausedError = false } = opts;
+    const prefix = isCausedError ? "Caused by: " : "";
+    const message = err.message ?? formatWithOptions(opts, err);
+    const stack = err.stack ? this.formatStack(err.stack, opts) : "";
+    const causedError = err.cause
+      ? "\n\n" + this.formatError(err.cause, { ...opts, isCausedError: true })
+      : "";
+    return prefix + message + "\n" + stack + causedError;
+  }
+
   formatArgs(args: any[], opts: FormatOptions) {
     const _args = args.map((arg) => {
       if (arg && typeof arg.stack === "string") {
-        return arg.message + "\n" + this.formatStack(arg.stack, opts);
+        return this.formatError(arg, opts);
       }
       return arg;
     });

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -46,9 +46,10 @@ function stringWidth(str: string) {
 }
 
 export class FancyReporter extends BasicReporter {
-  formatStack(stack: string) {
+  formatStack(stack: string, opts: FormatOptions) {
+    const indent = "  ".repeat((opts?.errorLevel || 0) + 1);
     return (
-      "\n" +
+      `\n${indent}` +
       parseStack(stack)
         .map(
           (line) =>
@@ -57,7 +58,7 @@ export class FancyReporter extends BasicReporter {
               .replace(/^at +/, (m) => colors.gray(m))
               .replace(/\((.+)\)/, (_, m) => `(${colors.cyan(m)})`),
         )
-        .join("\n")
+        .join(`\n${indent}`)
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,11 @@ export interface FormatOptions {
   compact?: boolean | number;
 
   /**
+   * Error cause level.
+   */
+  errorLevel?: number;
+
+  /**
    * Allows additional custom formatting options.
    */
   [key: string]: unknown;


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

The `cause` property of Error had been support in [most runtime](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#browser_compatibility) and been widely adapted by many repo.

The Chrome devtool already support showing caused error like screenshot below ⬇️

<img width="868" alt="image" src="https://github.com/unjs/consola/assets/35442047/21387423-7107-4369-bfed-64b3860d6c0a">

This PR support report error cause to console while used in node. Related issue #202 

<img width="540" alt="image" src="https://github.com/unjs/consola/assets/35442047/c056843f-d996-4e8e-964c-8d84438be4a3">

Test code provided:

```ts
import { consola } from "./src/index";

consola.error(
  new Error("This is an error", {
    cause: new Error("This is the cause", {
      cause: new Error("This is the cause of the cause"),
    }),
  }),
);

```
