### PR TITLE
feat(prompt): configurable cancel strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,17 @@ Log to all reporters.
 
 Example: `consola.info('Message')`
 
-#### `await prompt(message, { type })`
+#### `await prompt(message, { type, cancel })`
 
 Show an input prompt. Type can either of `text`, `confirm`, `select` or `multiselect`.
+
+If prompt is canceled by user (with Ctrol+C), default value will be resolved by default. This strategy can be configured by setting `{ cancel: "..." }` option:
+
+- `"default"` - Resolve the promise with the `default` value or `initial` value.
+- `"undefined`" - Resolve the promise with `undefined`.
+- `"null"` - Resolve the promise with `null`.
+- `"symbol"` - Resolve the promise with a symbol `Symbol.for("cancel")`.
+- `"reject"` - Reject the promise with an error.
 
 See [examples/prompt.ts](./examples/prompt.ts) for usage examples.
 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -6,7 +6,7 @@ type SelectOption = {
   hint?: string;
 };
 
-const kCancel = Symbol.for("cancel");
+export const kCancel = Symbol.for("cancel");
 
 export type PromptCommonOptions = {
   /**

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -164,22 +164,27 @@ export async function prompt<
     }
 
     switch (opts.cancel) {
-      case "reject":
+      case "reject": {
         const error = new Error("Prompt cancelled.");
         error.name = "ConsolaPromptCancelledError";
         if (Error.captureStackTrace) {
           Error.captureStackTrace(error, prompt);
         }
         throw error;
-      case "undefined":
+      }
+      case "undefined": {
         return undefined;
-      case "null":
+      }
+      case "null": {
         return null;
-      case "symbol":
+      }
+      case "symbol": {
         return kCancel;
+      }
       default:
-      case "default":
+      case "default": {
         return (opts as TextPromptOptions).default ?? opts.initial;
+      }
     }
   };
 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -130,14 +130,14 @@ export async function prompt<
       defaultValue: opts.default,
       placeholder: opts.placeholder,
       initialValue: opts.initial as string,
-    })) as any;
+    }).then(handleCancel)) as any;
   }
 
   if (opts.type === "confirm") {
     return (await confirm({
       message,
       initialValue: opts.initial,
-    })) as any;
+    }).then(handleCancel)) as any;
   }
 
   if (opts.type === "select") {
@@ -147,7 +147,7 @@ export async function prompt<
         typeof o === "string" ? { value: o, label: o } : o,
       ),
       initialValue: opts.initial,
-    })) as any;
+    }).then(handleCancel)) as any;
   }
 
   if (opts.type === "multiselect") {
@@ -158,8 +158,22 @@ export async function prompt<
       ),
       required: opts.required,
       initialValues: opts.initial,
-    })) as any;
+    }).then(handleCancel)) as any;
   }
 
   throw new Error(`Unknown prompt type: ${opts.type}`);
+}
+
+function handleCancel(value: any) {
+  if (
+    typeof value === "symbol" &&
+    value.toString() === "Symbol(clack:cancel)"
+  ) {
+    const error = new Error("Prompt cancelled.");
+    error.name = "ConsolaPromptCancelledError";
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(error, prompt);
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
Resolves #234 #251

When prompts get canceled by user Ctrl+C it was returning (untyped/undocumented) `Symbol(clack:cancel)`.

This PR adds a new `cancel` option to specify strategy:

- `"default"` - Resolve the promise with the `default` value or `initial` value.
- `"undefined`" - Resolve the promise with `undefined`.
- `"null"` - Resolve the promise with `null`.
- `"symbol"` - Resolve the promise with a symbol `Symbol.for("cancel")`.
- `"reject"` - Reject the promise with an error.

Default is set to `"default"` a small behavior change from current that returns the internal Clack symbol to keep backward compatibility with (expected) typed behavior.

Possible canceled return type is added