### PR TITLE
fix(fancy): fallback when`Intl` is unavailable

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -39,7 +39,8 @@ const TYPE_ICONS: { [k in LogType]?: string } = {
 
 function stringWidth(str: string) {
   // https://github.com/unjs/consola/issues/204
-  if (!Intl.Segmenter) {
+  const hasICU = typeof Intl === "object";
+  if (!hasICU || !Intl.Segmenter) {
     return stripAnsi(str).length;
   }
   return _stringWidth(str);


### PR DESCRIPTION
Added a fallback to handle cases where Intl isn’t available. This keeps things running smoothly even in environments without Intl support. For more details, check out the [Node.js docs on detecting internationalization support](https://nodejs.org/api/intl.html#detecting-internationalization-support).