### PR TITLE
feat: `consola.spinner`

### DIFF
--- a/examples/spinner.ts
+++ b/examples/spinner.ts
@@ -1,9 +1,13 @@
 import { consola } from "./utils";
 
+setInterval(() => {
+  console.log("foo");
+}, 100);
+
 async function main() {
-  consola.start("Creating project...");
+  const spinner = await consola.spinner("Creating project...");
   await new Promise((resolve) => setTimeout(resolve, 1000));
-  consola.success("Project created!");
+  spinner.stop("Project created!");
 }
 
 main();

--- a/src/clack.ts
+++ b/src/clack.ts
@@ -1,4 +1,10 @@
-import { text, confirm, select, multiselect } from "@clack/prompts";
+import {
+  text,
+  confirm,
+  select,
+  multiselect,
+  spinner as createSpinner,
+} from "@clack/prompts";
 
 type SelectOption = {
   label: string;
@@ -226,4 +232,18 @@ export async function prompt<
   }
 
   throw new Error(`Unknown prompt type: ${opts.type}`);
+}
+
+export interface Spinner {
+  start: (msg?: string) => void;
+  stop: (msg?: string, code?: number) => void;
+  message: (msg?: string) => void;
+}
+
+export function spinner(message?: string): Spinner {
+  const s = createSpinner();
+  if (message) {
+    s.start(message);
+  }
+  return s;
 }

--- a/src/consola.ts
+++ b/src/consola.ts
@@ -7,7 +7,7 @@ import type {
   LogObject,
   ConsolaOptions,
 } from "./types";
-import type { PromptOptions } from "./prompt";
+import type { PromptOptions, Spinner } from "./clack";
 
 let paused = false;
 const queue: any[] = [];
@@ -120,6 +120,18 @@ export class Consola {
       throw new Error("prompt is not supported!");
     }
     return this.options.prompt<any, any, T>(message, opts);
+  }
+
+  spinner(message: string): Promise<Spinner> {
+    if (!this.options.spinner) {
+      const consola = this as unknown as ConsolaInstance;
+      return Promise.resolve(<Spinner>{
+        start: (message) => consola.start(message),
+        stop: (message, _code) => consola.success(message),
+        message: (message) => consola.info(message),
+      });
+    }
+    return this.options.spinner(message);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ export function createConsola(
     defaults: { level },
     stdout: process.stdout,
     stderr: process.stderr,
-    prompt: (...args) => import("./prompt").then((m) => m.prompt(...args)),
+    prompt: (...args) => import("./clack").then((m) => m.prompt(...args)),
+    spinner: (...args) => import("./clack").then((m) => m.spinner(...args)),
     reporters: options.reporters || [
       (options.fancy ?? !(isCI || isTest))
         ? new FancyReporter()

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -10,4 +10,4 @@ export type {
   MultiSelectOptions,
   SelectPromptOptions,
   TextPromptOptions,
-} from "./prompt";
+} from "./clack";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { LogLevel, LogType } from "./constants";
+import type { Spinner } from "./clack";
 
 export interface ConsolaOptions {
   /**
@@ -54,7 +55,13 @@ export interface ConsolaOptions {
    * Custom prompt function to use. It can be undefined.
    * @optional
    */
-  prompt?: typeof import("./prompt").prompt | undefined;
+  prompt?: typeof import("./clack").prompt | undefined;
+
+  /**
+   * Custom spinner function to use. It can be undefined.
+   * @optional
+   */
+  spinner?: (message?: string) => Promise<Spinner>;
 
   /**
    * Configuration options for formatting log messages. See {@link FormatOptions}.


### PR DESCRIPTION
[wip draft]

Add `consola.spinner()` 


using clack utils but I discover some impl issues when in parallel to spinner logs are output. might replace with a better solution.