### PR TITLE
feat: animated spinner

### DIFF
--- a/examples/spinner.ts
+++ b/examples/spinner.ts
@@ -1,9 +1,16 @@
 import { consola } from "./utils";
 
-async function main() {
-  consola.start("Creating project...");
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  consola.success("Project created!");
+consola.wrapAll();
+
+// consola.start("Creating project");
+consola.start("Creating project \n  Name: 123");
+
+for (let i = 0; i <= 100; i++) {
+  if (i % 25 === 0) {
+    console.log(`Random info message ${i}`);
+    // consola.info(`Random info message ${i}`);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 10));
 }
 
-main();
+consola.success("Project created!");

--- a/src/reporters/basic.ts
+++ b/src/reporters/basic.ts
@@ -75,12 +75,15 @@ export class BasicReporter implements ConsolaReporter {
     ]);
   }
 
-  log(logObj: LogObject, ctx: { options: ConsolaOptions }) {
-    const line = this.formatLogObj(logObj, {
+  formatLine(logObj: LogObject, ctx: { options: ConsolaOptions }) {
+    return this.formatLogObj(logObj, {
       columns: (ctx.options.stdout as any).columns || 0,
       ...ctx.options.formatOptions,
     });
+  }
 
+  log(logObj: LogObject, ctx: { options: ConsolaOptions }) {
+    const line = this.formatLine(logObj, ctx);
     return writeStream(
       line + "\n",
       logObj.level < 2

--- a/src/utils/spinner.ts
+++ b/src/utils/spinner.ts
@@ -1,0 +1,57 @@
+import { writeStream } from "./stream";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+export class Spinner {
+  frameIndex: number = 0;
+  interval?: NodeJS.Timeout;
+  stream: NodeJS.WriteStream;
+  offset: number = 0;
+  paused: boolean = false;
+
+  constructor(message: string = "", stream?: NodeJS.WriteStream) {
+    this.stream = stream || process.stdout;
+
+    this.write(`${this.getFrame()} ${message}\n`);
+    this.offset = message.split("\n").length;
+
+    this.interval = setInterval(() => this.render(), 80);
+    this.interval.unref();
+  }
+
+  write(message: string) {
+    writeStream(message, this.stream);
+  }
+
+  render() {
+    if (this.paused) {
+      return;
+    }
+    const frame = this.getFrame();
+    return this.write(
+      this.offset
+        ? `\u001B[${this.offset}A\r${frame}\u001B[${this.offset}B\r`
+        : `\r${frame}`,
+    );
+  }
+
+  getFrame() {
+    return SPINNER_FRAMES[++this.frameIndex % SPINNER_FRAMES.length];
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = undefined;
+    }
+    this.stream.write(`\r\u001B[K`);
+  }
+}
+
+function spyOnStream(stream: NodeJS.WriteStream) {
+  const write = stream.__write || stream.write;
+  stream.write = function (chunk: any, ...args: any[]) {
+    console.log("write", chunk);
+    return write.call(stream, chunk, ...args);
+  };
+}

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,17 +1,18 @@
-/**
- * Writes data to a specified NodeJS writable stream. This function supports streams that have a custom
- * `__write' method, and will fall back to the default `write' method if `__write' is not present.
- *
- * @param {any} data - The data to write to the stream. This can be a string, a buffer, or any data type
- * supported by the stream's `write' or `__write' method.
- * @param {NodeJS.WriteStream} stream - The writable stream to write the data to. This stream
- * must implement the `write' method, and can optionally implement a custom `__write' method.
- * @returns {boolean} `true` if the data has been completely processed by the write operation,
- * indicating that further writes can be performed immediately. Returns `false` if the data is
- * buffered by the stream, indicating that the `drain` event should be waited for before writing
- * more data.
- */
-export function writeStream(data: any, stream: NodeJS.WriteStream) {
-  const write = (stream as any).__write || stream.write;
+import type { WriteStream } from "node:tty";
+
+interface ConsolaWriteStream extends WriteStream {
+  /** patched by consola.wrap*() */
+  __write?: WriteStream["write"];
+}
+
+export function writeStream(data: any, stream: ConsolaWriteStream) {
+  const write = stream.__write || stream.write;
   return write.call(stream, data);
+}
+
+export function spyOnStream(stream: WriteStream) {
+  const originalWrite = stream.write;
+  stream.write = function write(chunk: any, ...args: any[]) {
+    return originalWrite.call(stream, chunk, ...args);
+  };
 }


### PR DESCRIPTION
closes #284

This PR enables an animated spinner with `consola.start()` which is stopped by `consola.{sucess,fail,fatalerror}`

The implementation also handles multi-line interrupts when the spinner is spinning and another log happens. both for build-in consola methods and when `consola.wrapAll()` is active. 

[wip] it still can be problematic in ambiguous contexts, therefore we need a stable spy on stdout/stderr to _count_ new lines and track them.

This PR is also likely landing for consola v4 as behavior change could be a regression.