### PR TITLE
fix: calculate box width without escape sequence chars

### DIFF
--- a/examples/box.ts
+++ b/examples/box.ts
@@ -1,7 +1,12 @@
 import { consola } from "./utils";
+import { colors } from "../src/utils";
 
 function main() {
   consola.box(`I am the default banner`);
+
+  consola.box(
+    `${colors.red("I")} ${colors.yellowBright("am")} ${colors.yellow("the")} ${colors.green("rainbow")} ${colors.blue("banner")}`,
+  );
 
   consola.box({
     title: "Box with options",

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -256,7 +256,8 @@ export function box(text: string, _opts: BoxOpts = {}) {
     opts.style.padding % 2 === 0 ? opts.style.padding : opts.style.padding + 1;
   const height = textLines.length + paddingOffset;
   const width =
-    Math.max(...textLines.map((line) => stripAnsi(line).length)) + paddingOffset;
+    Math.max(...textLines.map((line) => stripAnsi(line).length)) +
+    paddingOffset;
   const widthOffset = width + paddingOffset;
 
   const leftSpace =

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -256,7 +256,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
     opts.style.padding % 2 === 0 ? opts.style.padding : opts.style.padding + 1;
   const height = textLines.length + paddingOffset;
   const width =
-    Math.max(...textLines.map((line) => line.length)) + paddingOffset;
+    Math.max(...textLines.map((line) => stripAnsi(line).length)) + paddingOffset;
   const widthOffset = width + paddingOffset;
 
   const leftSpace =


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #316 
