### PR TITLE
fix: remove all message lines from stack

### DIFF
--- a/examples/error.ts
+++ b/examples/error.ts
@@ -1,6 +1,6 @@
 import { consola } from "./utils";
 
-const error = new Error("This is an error", {
+const error = new Error("This is an error\nWith second line\nAnd another", {
   cause: new Error("This is the cause", {
     cause: new Error("This is the cause of the cause"),
   }),

--- a/src/reporters/basic.ts
+++ b/src/reporters/basic.ts
@@ -11,14 +11,14 @@ import { writeStream } from "../utils/stream";
 const bracket = (x: string) => (x ? `[${x}]` : "");
 
 export class BasicReporter implements ConsolaReporter {
-  formatStack(stack: string, opts: FormatOptions) {
+  formatStack(stack: string, message: string, opts: FormatOptions) {
     const indent = "  ".repeat((opts?.errorLevel || 0) + 1);
-    return indent + parseStack(stack).join(`\n${indent}`);
+    return indent + parseStack(stack, message).join(`\n${indent}`);
   }
 
   formatError(err: any, opts: FormatOptions): string {
     const message = err.message ?? formatWithOptions(opts, err);
-    const stack = err.stack ? this.formatStack(err.stack, opts) : "";
+    const stack = err.stack ? this.formatStack(err.stack, message, opts) : "";
 
     const level = opts?.errorLevel || 0;
     const causedPrefix = level > 0 ? `${"  ".repeat(level)}[cause]: ` : "";

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -47,11 +47,11 @@ function stringWidth(str: string) {
 }
 
 export class FancyReporter extends BasicReporter {
-  formatStack(stack: string, opts: FormatOptions) {
+  formatStack(stack: string, message: string, opts?: FormatOptions) {
     const indent = "  ".repeat((opts?.errorLevel || 0) + 1);
     return (
       `\n${indent}` +
-      parseStack(stack)
+      parseStack(stack, message)
         .map(
           (line) =>
             "  " +
@@ -127,7 +127,7 @@ export class FancyReporter extends BasicReporter {
 
     if (logObj.type === "trace") {
       const _err = new Error("Trace: " + logObj.message);
-      line += this.formatStack(_err.stack || "");
+      line += this.formatStack(_err.stack || "", _err.message);
     }
 
     return isBadge ? "\n" + line + "\n" : line;

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -5,12 +5,12 @@ import { sep } from "node:path";
  * @param {string} stack - The stack trace string.
  * @returns {string[]} An array of stack trace lines with normalised paths.
  */
-export function parseStack(stack: string) {
+export function parseStack(stack: string, message: string) {
   const cwd = process.cwd() + sep;
 
   const lines = stack
     .split("\n")
-    .splice(1)
+    .splice(message.split("\n").length)
     .map((l) => l.trim().replace("file://", "").replace(cwd, ""));
 
   return lines;


### PR DESCRIPTION
Resolves #355

If an error message contains multiple lines, we need to count them and remove them from the beginning of the stack (previously we was assumed to drop hardcoded number of `1` lines)