### PR TITLE
refactor: improve `logFn` types

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "lint": "eslint . && prettier -c src examples test",
     "lint:fix": "eslint . --fix && prettier -w src examples test",
     "release": "pnpm test && pnpm build && changelogen --release --push && npm publish",
-    "test": "pnpm lint && pnpm vitest run --coverage"
+    "test": "pnpm lint && pnpm vitest run --typecheck --coverage"
   },
   "devDependencies": {
     "@clack/prompts": "^0.10.0",

--- a/src/consola.ts
+++ b/src/consola.ts
@@ -474,8 +474,15 @@ function _normalizeLogLevel(
   return defaultLevel;
 }
 
+// Should match with `isLogObj()`
+type LogParam<T> = T extends { message: any } | { args: any }
+  ? T extends { stack: any }
+    ? T
+    : InputLogObject
+  : T;
+
 export interface LogFn {
-  (message: InputLogObject | any, ...args: any[]): void;
+  <T>(message: LogParam<T>, ...args: any[]): void;
   raw: (...args: any[]) => void;
 }
 export type ConsolaInstance = Consola & Record<LogType, LogFn>;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error no types
 import { vsprintf } from "printj";
 
 // Predefined rules for replacing format arguments

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -9,6 +9,12 @@ export function isPlainObject(obj: any) {
   return Object.prototype.toString.call(obj) === "[object Object]";
 }
 
+/**
+ * Determines whether the given argument is a protocol object. A log object must be a simple object and
+ * must contain either a 'message' or 'args' field, but not a 'stack' field.
+ * @param {any} arg - The argument to check.
+ * @returns {boolean} `true` if the argument is a log object according to the specified criteria, otherwise `false`.
+ */
 export function isLogObj(arg: any): arg is InputLogObject {
   // Should be plain object
   if (!isPlainObject(arg)) {

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,3 +1,5 @@
+import type { InputLogObject } from "../types";
+
 /**
  * Checks if the given argument is a simple JavaScript object.
  * @param {any} obj - The object to test.
@@ -7,13 +9,7 @@ export function isPlainObject(obj: any) {
   return Object.prototype.toString.call(obj) === "[object Object]";
 }
 
-/**
- * Determines whether the given argument is a protocol object. A log object must be a simple object and
- * must contain either a 'message' or 'args' field, but not a 'stack' field.
- * @param {any} arg - The argument to check.
- * @returns {boolean} `true` if the argument is a log object according to the specified criteria, otherwise `false`.
- */
-export function isLogObj(arg: any) {
+export function isLogObj(arg: any): arg is InputLogObject {
   // Should be plain object
   if (!isPlainObject(arg)) {
     return false;

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -58,7 +58,7 @@ describe("consola", () => {
   });
 });
 
-function wait(delay) {
+function wait(delay: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, delay);
   });

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -15,6 +15,6 @@ describe("consola", () => {
     // @ts-expect-error should error for invalid args/date type
     assertType(consola.log({ args: "hi", date: "2025-03-25" }));
     // @ts-expect-error should error for invalid date type
-    assertType(consola.log({args: ["hi"], date: "2025-03-25"}));
+    assertType(consola.log({ args: ["hi"], date: "2025-03-25" }));
   });
 });

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,0 +1,20 @@
+import { describe, test, assertType } from "vitest";
+import { consola } from "../src";
+
+describe("consola", () => {
+  test("should warn for invalid log param types", () => {
+    assertType(consola.log("hi", 42, true));
+
+    assertType(consola.log({ message: "hi" }));
+    assertType(consola.log({ message: "hi", date: new Date() }));
+    // @ts-expect-error should error for invalid date type
+    assertType(consola.log({ message: "hi", date: "2025-03-25" }));
+
+    assertType(consola.log({ args: ["hi"] }));
+    assertType(consola.log({ args: ["hi"], date: new Date() }));
+    // @ts-expect-error should error for invalid args/date type
+    assertType(consola.log({ args: "hi", date: "2025-03-25" }));
+    // @ts-expect-error should error for invalid date type
+    assertType(consola.log({args: ["hi"], date: "2025-03-25"}));
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "Node",
     "esModuleInterop": true,
     "strict": true,
-    "types": ["vitest/globals", "node"]
+    "types": ["vitest/globals", "node"],
+    "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #351

Since `logObj.date` must be of type `Date`, we should enforce stricter parameter types to prevent runtime errors.
In addition to `formatDate` requiring the `Date` type, we also use the `Date` internally:
https://github.com/unjs/consola/blob/5ac9ed76b021c9ffc768f0727355238056aabeb1/src/consola.ts#L418-L422