### PR TITLE
feat!: use native `stripVTControlCharacters`

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,6 @@ describe("your-consola-mock-test", () => {
 ```ts
 // ESM
 import {
-  stripAnsi,
   centerAlign,
   rightAlign,
   leftAlign,
@@ -336,7 +335,7 @@ import {
 } from "consola/utils";
 
 // CommonJS
-const { stripAnsi } = require("consola/utils");
+const { centerAlign } = require("consola/utils");
 ```
 
 ## Raw logging methods

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "vitest": "^3.0.9"
   },
   "engines": {
-    "node": "^14.18.0 || >=16.10.0"
+    "node": ">=16.11.0"
   },
   "packageManager": "pnpm@10.6.3"
 }

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'node:util'
+import { stripVTControlCharacters } from "node:util";
 import _stringWidth from "string-width";
 import isUnicodeSupported from "is-unicode-supported";
 import { colors } from "../utils/color";

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from 'node:util'
 import _stringWidth from "string-width";
 import isUnicodeSupported from "is-unicode-supported";
 import { colors } from "../utils/color";
@@ -5,7 +6,6 @@ import { parseStack } from "../utils/error";
 import { FormatOptions, LogObject } from "../types";
 import { LogLevel, LogType } from "../constants";
 import { BoxOpts, box } from "../utils/box";
-import { stripAnsi } from "../utils";
 import { BasicReporter } from "./basic";
 
 export const TYPE_COLOR_MAP: { [k in LogType]?: string } = {
@@ -41,7 +41,7 @@ function stringWidth(str: string) {
   // https://github.com/unjs/consola/issues/204
   const hasICU = typeof Intl === "object";
   if (!hasICU || !Intl.Segmenter) {
-    return stripAnsi(str).length;
+    return stripVTControlCharacters(str).length;
   }
   return _stringWidth(str);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,6 @@
 export * from "./utils/box";
 export * from "./utils/color";
-export {
-  centerAlign,
-  rightAlign,
-  leftAlign,
-  align,
-} from "./utils/string";
+export { centerAlign, rightAlign, leftAlign, align } from "./utils/string";
 export {
   type TreeItemObject,
   type TreeItem,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,6 @@
 export * from "./utils/box";
 export * from "./utils/color";
 export {
-  stripAnsi,
   centerAlign,
   rightAlign,
   leftAlign,

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,5 +1,5 @@
+import { stripVTControlCharacters } from 'node:util'
 import { getColor } from "./color";
-import { stripAnsi } from "./string";
 
 export type BoxBorderStyle = {
   /**
@@ -257,8 +257,8 @@ export function box(text: string, _opts: BoxOpts = {}) {
   const height = textLines.length + paddingOffset;
   const width =
     Math.max(
-      ...textLines.map((line) => stripAnsi(line).length),
-      opts.title ? stripAnsi(opts.title).length : 0,
+      ...textLines.map((line) => stripVTControlCharacters(line).length),
+      opts.title ? stripVTControlCharacters(opts.title).length : 0,
     ) + paddingOffset;
   const widthOffset = width + paddingOffset;
 
@@ -273,12 +273,12 @@ export function box(text: string, _opts: BoxOpts = {}) {
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
     const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
+      Math.floor((width - stripVTControlCharacters(opts.title).length) / 2),
     );
     const right = borderStyle.h.repeat(
       width -
-        stripAnsi(opts.title).length -
-        stripAnsi(left).length +
+        stripVTControlCharacters(opts.title).length -
+        stripVTControlCharacters(left).length +
         paddingOffset,
     );
     boxLines.push(
@@ -312,7 +312,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
       // Text line
       const line = textLines[i - valignOffset];
       const left = " ".repeat(paddingOffset);
-      const right = " ".repeat(width - stripAnsi(line).length);
+      const right = " ".repeat(width - stripVTControlCharacters(line).length);
       boxLines.push(
         `${leftSpace}${borderStyle.v}${left}${line}${right}${borderStyle.v}`,
       );

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,4 +1,4 @@
-import { stripVTControlCharacters } from 'node:util'
+import { stripVTControlCharacters } from "node:util";
 import { getColor } from "./color";
 
 export type BoxBorderStyle = {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,20 +1,3 @@
-const ansiRegex = [
-  String.raw`[\u001B\u009B][[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d\/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d\/#&.:=?%@~_]*)*)?\u0007)`,
-  String.raw`(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))`,
-].join("|");
-
-/**
- * Removes ANSI escape codes from a given string. This is particularly useful for
- * processing text that contains formatting codes, such as colours or styles, so that the
- * the raw text without any visual formatting.
- *
- * @param {string} text - The text string from which to strip the ANSI escape codes.
- * @returns {string} The text without ANSI escape codes.
- */
-export function stripAnsi(text: string) {
-  return text.replace(new RegExp(ansiRegex, "g"), "");
-}
-
 /**
  * Centers a string within a specified total width, padding it with spaces or another specified character.
  * If the string is longer than the total width, it is returned as is.


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #377

This PR:

- Migrates `stripAnsi` to Node.js native [stripVTControlCharacters](https://nodejs.org/docs/latest/api/util.html#utilstripvtcontrolcharactersstr)

- Removes the exported `stripAnsi` since it contains no additional logic. 
Users should use [stripVTControlCharacters](https://nodejs.org/docs/latest/api/util.html#utilstripvtcontrolcharactersstr) directly. 
(Or do you suggest keeping it exported to minimize breaking changes? 🤔)

- Bumps the `engines` to `"node": ">=16.11.0"`
