### PR TITLE
fix: update fancy reporter backticks highlighter

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -138,7 +138,7 @@ function characterFormat(str: string) {
   return (
     str
       // highlight backticks
-      .replace(/`([^`]+)`/gm, (_, m) => colors.cyan(m))
+      .replace(/`([^`\n]+?)`/gm, (_, m) => colors.cyan(['`', m, '`'].join('')))
       // underline underscores
       .replace(/\s+_([^_]+)_\s+/gm, (_, m) => ` ${colors.underline(m)} `)
   );

--- a/test/fancy.test.ts
+++ b/test/fancy.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "vitest";
+import type { LogObject } from "../src";
+import { FancyReporter } from "../src/reporters/fancy";
+
+describe("fancy reporter", () => {
+  test("should correctly wrap single-line backticks", () => {
+    const reporter = new FancyReporter();
+
+    const input = '`hello world`'
+
+    const logObj: LogObject =  {
+      args: [
+        input,
+      ],
+      date: new Date(),
+      level: 2,
+      tag: "",
+      type: "log",
+    }
+
+    const resp = reporter.formatLogObj(logObj, {});
+    expect(resp).toBe(input);
+  });
+  test("should correctly wrap multi-line backticks", () => {
+    const reporter = new FancyReporter();
+
+    const input = [
+      '```html',
+      '<div>hello</div>',
+      '```',
+
+      '```html',
+      '<div>hello</div>',
+      '```',
+    ].join('\n')
+
+    const logObj: LogObject =  {
+      args: [
+        input,
+      ],
+      date: new Date(),
+      level: 2,
+      tag: "",
+      type: "log",
+    }
+
+    const resp = reporter.formatLogObj(logObj, {});
+    expect(resp).toBe(input);
+  });
+});


### PR DESCRIPTION
Resolves #380 

This PR ensure only single-line backticks are fancied and that backticks remains to the output.
Also added tests about single-line and multi-line backticks (markdown style).

I'm wondering if we want to color multi-line ? Not sure if it's relevant. We can do so with a regex like:
```
`([^`\n]+?)`|`{3}([\s\S]*?)`{3}
```