### PR TITLE
refactor: remove unnecessary expression

### DIFF
--- a/src/reporters/basic.ts
+++ b/src/reporters/basic.ts
@@ -56,11 +56,7 @@ export class BasicReporter implements ConsolaReporter {
     if (logObj.type === "box") {
       return (
         "\n" +
-        [
-          bracket(logObj.tag),
-          logObj.title && logObj.title,
-          ...message.split("\n"),
-        ]
+        [bracket(logObj.tag), logObj.title, ...message.split("\n")]
           .filter(Boolean)
           .map((l) => " > " + l)
           .join("\n") +


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

It should be fine to reduce `logObj.title && logObj.title` to `logObj.title`. Perhaps `logObj && logObj.title` was intended, but since this is within `if (logObj.type === "box") {}`, `logObj` should be defined.
