### PR TITLE
refactor: use std-env for color support detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,5 +132,10 @@
   "engines": {
     "node": "^14.18.0 || >=16.10.0"
   },
-  "packageManager": "pnpm@10.6.3"
+  "packageManager": "pnpm@10.6.3",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  }
 }

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -4,31 +4,7 @@
  * https://github.com/jorgebucaran/colorette/blob/20fc196d07d0f87c61e0256eadd7831c79b24108/index.js
  */
 
-import * as tty from "node:tty";
-
-// TODO: Migrate to std-env
-const {
-  env = {},
-  argv = [],
-  platform = "",
-} = typeof process === "undefined" ? {} : process;
-const isDisabled = "NO_COLOR" in env || argv.includes("--no-color");
-const isForced = "FORCE_COLOR" in env || argv.includes("--color");
-const isWindows = platform === "win32";
-const isDumbTerminal = env.TERM === "dumb";
-const isCompatibleTerminal =
-  tty && tty.isatty && tty.isatty(1) && env.TERM && !isDumbTerminal;
-const isCI =
-  "CI" in env &&
-  ("GITHUB_ACTIONS" in env || "GITLAB_CI" in env || "CIRCLECI" in env);
-
-/**
- * Determines support for terminal colours based on the environment and capabilities of the terminal.
- * @type {boolean} isColorSupported - Indicates whether colour support is enabled in the terminal.
- */
-const isColorSupported =
-  !isDisabled &&
-  (isForced || (isWindows && !isDumbTerminal) || isCompatibleTerminal || isCI);
+import { isColorSupported } from "std-env";
 
 function replaceClose(
   index: number,


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR addresses the TODO in ./src/utils/color.ts to migrate color support detection to std-env(#386 ). It replaces manual checks (e.g., process.env, process.argv) with std-env's isColorSupported flag

### Linked Issues

fixes #386 