### PR TITLE
feat: implement table method (resolves #318)

### DIFF
--- a/examples/table.ts
+++ b/examples/table.ts
@@ -1,0 +1,112 @@
+import { consola } from "./utils";
+
+function main() {
+  consola.table([
+    { Name: "Pikachu", Type: "Electric", Level: 25 },
+    { Name: "Charizard", Type: "Fire/Flying", Level: 50 },
+    { Name: "Bulbasaur", Type: "Grass/Poison", Level: 5 },
+  ]);
+
+  consola.table({
+    "Column 1": "Row 1 Value",
+    "Column 2": "Row 1 Value",
+    "Column 3": "Row 1 Value",
+  });
+
+  consola.table(12_345);
+  consola.table(["apples", "oranges", "bananas"]);
+
+  consola.table([
+    ["Tyrone", "Jones"],
+    ["Janet", "Smith"],
+    ["Maria", "Cruz"],
+  ]);
+
+  function Person(firstName: string, lastName: string) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+
+  const family = {
+    mother: new Person("Janet", "Jones"),
+    father: new Person("Tyrone", "Kirby"),
+    daughter: new Person("Maria", "Dina"),
+  };
+
+  consola.table(family);
+
+  consola.table([
+    {
+      id: 1,
+      user: { name: "Alice", role: "Admin" },
+      tags: ["system", "critical"],
+      metrics: { cpu: 0.95, memory: 1024, disk: null },
+      enabled: true,
+      timestamp: new Date("2023-01-15T10:00:00Z"),
+      settings: undefined,
+    },
+    {
+      id: 2,
+      user: { name: "Bob", role: "User" },
+      tags: ["data", "report", "long tag example"],
+      metrics: { cpu: 0.5, memory: 512, disk: 50.5 },
+      enabled: false,
+      timestamp: new Date("2023-01-16T12:30:00Z"),
+      settings: { theme: "dark", notifications: [1, 2] },
+    },
+    {
+      id: 3,
+      user: { name: "Charlie", role: "Guest" },
+      tags: [],
+      metrics: { cpu: Number.NaN, memory: Infinity },
+      enabled: true,
+      timestamp: new Date("2023-01-17T15:45:00Z"),
+      settings: { theme: "light" },
+    },
+  ]);
+
+  // Table options
+  consola.table(["apples", "oranges", "bananas"], { padding: 0 });
+
+  consola.table(
+    [
+      { Name: "Pikachu", Type: "Electric", Level: 25 },
+      { Name: "Charizard", Type: "Fire/Flying", Level: 50 },
+      { Name: "Bulbasaur", Type: "Grass/Poison", Level: 5 },
+    ],
+    ["Type"],
+  );
+
+  consola.table(
+    [
+      { Name: "Pikachu", Type: "Electric", Level: 25 },
+      { Name: "Charizard", Type: "Fire/Flying", Level: 50 },
+      { Name: "Bulbasaur", Type: "Grass/Poison", Level: 5 },
+    ],
+    ["Name"],
+    { border: false },
+  );
+
+  consola.table(
+    [
+      { Name: "Pikachu", Type: "Electric", Level: 25 },
+      { Name: "Charizard", Type: "Fire/Flying", Level: 50 },
+      { Name: "Bulbasaur", Type: "Grass/Poison", Level: 5 },
+    ],
+    { border: false },
+  );
+
+  consola.table(
+    [
+      { Name: "Pikachu", Type: "Electric", Level: 25 },
+      { Name: "Charizard", Type: "Fire/Flying", Level: 50 },
+      { Name: "Bulbasaur", Type: "Grass/Poison", Level: 5 },
+    ],
+    {
+      borderColor: "blue",
+      tableStyle: { head: ["green"] },
+    },
+  );
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -106,11 +106,11 @@
   ],
   "scripts": {
     "build": "unbuild",
-    "dev": "vitest",
+    "dev": "FORCE_COLOR=1 vitest",
     "lint": "eslint . && prettier -c src examples test",
     "lint:fix": "eslint . --fix && prettier -w src examples test",
     "release": "pnpm test && pnpm build && changelogen --release --push && npm publish",
-    "test": "pnpm lint && pnpm vitest run --coverage"
+    "test": "FORCE_COLOR=1 pnpm lint && pnpm vitest run --coverage"
   },
   "devDependencies": {
     "@clack/prompts": "^0.10.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,7 @@ export const LogLevels: Record<LogType, number> = {
   ready: 3,
   start: 3,
   box: 3,
+  table: 3,
 
   debug: 4,
 
@@ -58,6 +59,7 @@ export type LogType =
   | "ready"
   | "start"
   | "box"
+  | "table"
   // Verbose
   | "debug"
   | "trace"
@@ -109,6 +111,9 @@ export const LogTypes: Record<LogType, Partial<LogObject>> = {
     level: LogLevels.info,
   },
   box: {
+    level: LogLevels.info,
+  },
+  table: {
     level: LogLevels.info,
   },
 

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -7,6 +7,8 @@ import { LogLevel, LogType } from "../constants";
 import { BoxOpts, box } from "../utils/box";
 import { stripAnsi } from "../utils";
 import { BasicReporter } from "./basic";
+import { createTable } from "../utils/table";
+import { parseTableArgs } from "../utils/table";
 
 export const TYPE_COLOR_MAP: { [k in LogType]?: string } = {
   info: "cyan",
@@ -87,6 +89,15 @@ export class FancyReporter extends BasicReporter {
     const [message, ...additional] = this.formatArgs(logObj.args, opts).split(
       "\n",
     );
+
+    if (logObj.type === "table") {
+      const data = logObj.args[0];
+      const { filterColumns, options: normOptions } = parseTableArgs(
+        logObj.args?.[1],
+        logObj.args?.[2],
+      );
+      return "\n" + createTable(data, filterColumns, normOptions);
+    }
 
     if (logObj.type === "box") {
       return box(

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,0 +1,680 @@
+import { colors, ColorName } from "./color";
+import { BoxBorderStyle } from "./box";
+import { align, stripAnsi } from "./string";
+
+/**
+ * Converts a value to its string representation for table display.
+ * Handles null, undefined, and objects (shows as "{…}").
+ * @param value - The value to convert.
+ * @returns The string representation for table display.
+ */
+export function stringifyValue(value: any): string {
+  if (value === null) {
+    return "null";
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (typeof value === "object" && !Array.isArray(value) && value !== null) {
+    return "{…}";
+  }
+  return String(value);
+}
+
+/**
+ * Normalizes input data into a table structure with headers and rows.
+ * Handles arrays (of objects, arrays, or primitives) and objects (simple or nested).
+ * Adds an (index) column for most types except simple key-value objects.
+ * @param data - The raw input data.
+ * @returns An object with { head, rows } or null if data is empty/invalid.
+ */
+export function normalizeTableData(
+  data: unknown,
+): { head: string[]; rows: string[][] } | null {
+  let head: string[] = [];
+  let rows: string[][] = [];
+  let addIndexColumn = false;
+  let indexType: "numeric" | "keys" = "numeric";
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      return null;
+    }
+    const firstItem = data[0];
+
+    if (
+      typeof firstItem === "object" &&
+      firstItem !== null &&
+      !Array.isArray(firstItem)
+    ) {
+      head = Object.keys(firstItem);
+      rows = data.map((row) =>
+        head.map((h) => stringifyValue((row as any)[h])),
+      );
+      addIndexColumn = true;
+      indexType = "numeric";
+    } else if (data.every((item) => Array.isArray(item))) {
+      // Array of arrays: Use numeric indices as headers.
+      const numCols = data[0]?.length || 0;
+      head = Array.from({ length: numCols }, (_, i) => String(i));
+      rows = data.map((row) =>
+        Array.from({ length: numCols }, (_, i) => stringifyValue(row[i])),
+      );
+      addIndexColumn = true;
+      indexType = "numeric";
+    } else {
+      // Simple array (primitives): Use 'Value' as header.
+      head = ["Value"];
+      rows = data.map((item) => [stringifyValue(item)]);
+      addIndexColumn = true;
+      indexType = "numeric";
+    }
+  } else if (typeof data === "object" && data !== null) {
+    const keys = Object.keys(data);
+    if (keys.length === 0) {
+      return null;
+    }
+
+    const firstValue = (data as any)[keys[0]];
+    const isObjectOfObjects =
+      typeof firstValue === "object" &&
+      firstValue !== null &&
+      !Array.isArray(firstValue) &&
+      keys.every((k) => {
+        const val = (data as any)[k];
+        return typeof val === "object" && val !== null && !Array.isArray(val);
+      });
+
+    if (isObjectOfObjects) {
+      // Object of objects: Use inner keys as headers, outer keys become index.
+      const innerKeys = Object.keys(firstValue).sort();
+      head = innerKeys;
+      rows = keys.map((key) => {
+        const innerObj = (data as any)[key];
+        return innerKeys.map((ik) => stringifyValue(innerObj[ik]));
+      });
+      addIndexColumn = true;
+      indexType = "keys";
+    } else {
+      // Simple Key-value object: Use 'Key' and 'Value' headers.
+      head = ["Key", "Value"];
+      rows = keys.map((key) => [key, stringifyValue((data as any)[key])]);
+      addIndexColumn = false;
+    }
+  } else {
+    return null;
+  }
+
+  // Add (index) column uniformly if required
+  if (addIndexColumn) {
+    head.unshift("(index)");
+    if (indexType === "numeric") {
+      rows = rows.map((row, i) => [String(i), ...row]);
+    } else {
+      const outerKeys = Object.keys(data as object);
+      rows = rows.map((row, i) => [outerKeys[i], ...row]);
+    }
+  }
+
+  if (head.length === 0 && rows.length === 0 && !addIndexColumn) {
+    return null;
+  }
+
+  return { head, rows };
+}
+
+/**
+ * Ensures all rows have the same number of columns as the header.
+ * Pads with empty strings or truncates as needed.
+ * @param head - The header array.
+ * @param rows - The initial rows array.
+ * @returns The normalized rows array.
+ */
+export function normalizeTableRows(
+  head: string[],
+  rows: string[][],
+): string[][] {
+  const numCols = head.length;
+  return rows.map((row) => {
+    const fullRow = [...row];
+    while (fullRow.length < numCols) {
+      fullRow.push("");
+    }
+    return fullRow.slice(0, numCols);
+  });
+}
+
+/**
+ * Calculates the required width for each column based on header and row content.
+ * @param headers - The header row strings.
+ * @param rows - The data row strings.
+ * @returns An array containing the calculated width for each column.
+ */
+export function calculateColumnWidths(
+  headers: string[],
+  rows: string[][],
+): number[] {
+  const widths = headers.map((h) => h.length);
+
+  for (const row of rows) {
+    for (const [i, cell] of row.entries()) {
+      if (i >= widths.length) {
+        widths.push(0);
+      }
+      widths[i] = Math.max(widths[i] ?? 0, cell.length);
+    }
+  }
+
+  return widths;
+}
+
+/**
+ * Table border style definition, extending BoxBorderStyle with junction characters.
+ */
+export type TableBorderStyle = BoxBorderStyle & {
+  /**
+   * Middle cross junction
+   * @example `┼`
+   * @example `╬`
+   */
+  mc: string;
+  /**
+   * Middle top tee junction
+   * @example `┬`
+   * @example `╦`
+   */
+  mt: string;
+  /** Middle bottom tee junction
+   * @example `┴`
+   * @example `╩`
+   */
+  mb: string;
+  /**
+   * Middle left tee junction
+   * @example `├`
+   * @example `╠`
+   */
+  ml: string;
+  /**
+   * Middle right tee junction
+   * @example `┤`
+   * @example `╣`
+   */
+  mr: string;
+};
+
+/**
+ * Preset border styles for tables, each providing a full TableBorderStyle.
+ */
+export const tableStylePresets: Record<string, TableBorderStyle> = {
+  solid: {
+    tl: "┌",
+    tr: "┐",
+    bl: "└",
+    br: "┘",
+    h: "─",
+    v: "│",
+    mc: "┼",
+    mt: "┬",
+    mb: "┴",
+    ml: "├",
+    mr: "┤",
+  },
+  double: {
+    tl: "╔",
+    tr: "╗",
+    bl: "╚",
+    br: "╝",
+    h: "═",
+    v: "║",
+    mc: "╬",
+    mt: "╦",
+    mb: "╩",
+    ml: "╠",
+    mr: "╣",
+  },
+  doubleSingle: {
+    tl: "╓",
+    tr: "╖",
+    bl: "╙",
+    br: "╜",
+    h: "─",
+    v: "║",
+    mc: "╫",
+    mt: "╥",
+    mb: "╨",
+    ml: "╟",
+    mr: "╢",
+  },
+  doubleSingleRounded: {
+    tl: "╭",
+    tr: "╮",
+    bl: "╰",
+    br: "╯",
+    h: "─",
+    v: "║",
+    mc: "╫",
+    mt: "╥",
+    mb: "╨",
+    ml: "╟",
+    mr: "╢",
+  },
+  singleThick: {
+    tl: "┏",
+    tr: "┓",
+    bl: "┗",
+    br: "┛",
+    h: "━",
+    v: "┃",
+    mc: "╋",
+    mt: "┳",
+    mb: "┻",
+    ml: "┣",
+    mr: "┫",
+  },
+  singleDouble: {
+    tl: "╒",
+    tr: "╕",
+    bl: "╘",
+    br: "╛",
+    h: "═",
+    v: "│",
+    mc: "╪",
+    mt: "╤",
+    mb: "╧",
+    ml: "╞",
+    mr: "╡",
+  },
+  singleDoubleRounded: {
+    tl: "╭",
+    tr: "╮",
+    bl: "╰",
+    br: "╯",
+    h: "═",
+    v: "│",
+    mc: "╪",
+    mt: "╤",
+    mb: "╧",
+    ml: "╞",
+    mr: "╡",
+  },
+  rounded: {
+    tl: "╭",
+    tr: "╮",
+    bl: "╰",
+    br: "╯",
+    h: "─",
+    v: "│",
+    mc: "┼",
+    mt: "┬",
+    mb: "┴",
+    ml: "├",
+    mr: "┤",
+  },
+};
+
+/**
+ * Options for customizing table appearance and style.
+ */
+export interface TableOptions {
+  tableStyle?: { head?: ColorName[] }; // Header color(s)
+  padding?: number; // Spaces inside each cell
+  border?: boolean; // Draw border around table
+  borderColor?: ColorName; // Color for border lines
+  borderStyle?: keyof typeof tableStylePresets | TableBorderStyle; // Border style preset or custom
+}
+
+/**
+ * Calculates the visual width of a string, ignoring ANSI escape codes.
+ * @param text - The input string.
+ * @returns The visual width (number of characters, not bytes).
+ */
+function _getMaxWidth(text: string): number {
+  return stripAnsi(text).length;
+}
+
+/**
+ * Calculates the required width for each column, including padding.
+ * @param head - The header row strings.
+ * @param rows - The data row strings.
+ * @param padding - Spaces to add to each side of cell content.
+ * @returns Array of column widths.
+ */
+function _calculateColumnWidths(
+  head: string[],
+  rows: string[][],
+  padding: number,
+): number[] {
+  // Initialize widths with header widths
+  const widths = head.map((h) => _getMaxWidth(h));
+
+  // Update widths based on row content
+  for (const row of rows) {
+    for (const [i, cell] of row.entries()) {
+      if (i >= widths.length) {
+        widths.push(0);
+      }
+      widths[i] = Math.max(widths[i] ?? 0, _getMaxWidth(cell));
+    }
+  }
+
+  // Add padding to each column width
+  return widths.map((w) => w + padding * 2);
+}
+
+/**
+ * Renders the header and content rows as strings, applying alignment, padding, and color.
+ * @param head - The header array.
+ * @param rows - The normalized rows array.
+ * @param columnWidths - Calculated widths for each column.
+ * @param padding - Cell padding.
+ * @param options - Table options (for styling, border).
+ * @param borderChars - Border characters to use.
+ * @param colorFns - Color functions for header and border.
+ * @returns Object with headerRow and contentRows as strings.
+ */
+function _renderTableRows(
+  head: string[],
+  rows: string[][],
+  columnWidths: number[],
+  padding: number,
+  options: TableOptions,
+  borderChars: TableBorderStyle,
+  colorFns: {
+    header?: (str: string) => string;
+    border?: (str: string) => string;
+  },
+): { headerRow: string; contentRows: string[] } {
+  const { border = true } = options;
+  const { header: headerColorFn, border: borderColorFn } = colorFns;
+
+  const padStr = " ".repeat(padding);
+  const alignments = columnWidths.map(() => "left" as const);
+
+  const renderRow = (rowData: string[], isHeader = false): string => {
+    const cells = rowData.map((cell, i) => {
+      const colWidth = columnWidths[i];
+      const alignType = alignments[i];
+      const contentWidth = colWidth > padding * 2 ? colWidth - padding * 2 : 0;
+      let cellContent = align(alignType, cell, contentWidth);
+      if (isHeader && headerColorFn) {
+        cellContent = headerColorFn(cellContent);
+      }
+      return padStr + cellContent + padStr;
+    });
+    const vBorder = borderColorFn
+      ? borderColorFn(borderChars.v)
+      : borderChars.v;
+    return border
+      ? `${vBorder}${cells.join(vBorder)}${vBorder}`
+      : cells.join(" ");
+  };
+
+  const headerRow = head.length > 0 ? renderRow(head, true) : "";
+  const contentRows = rows.map((row) => renderRow(row));
+
+  return { headerRow, contentRows };
+}
+
+/**
+ * Creates a horizontal border line for the table (top, middle, or bottom).
+ * @param widths - Array of column widths.
+ * @param borderChars - The character set for the border.
+ * @param type - The type of line ('top', 'middle', 'bottom').
+ * @param borderColorFn - Optional function to apply color to border characters.
+ * @returns The formatted horizontal line string.
+ */
+function _createHorizontalLine(
+  widths: number[],
+  borderChars: TableBorderStyle,
+  type: "top" | "middle" | "bottom",
+  borderColorFn?: (str: string) => string,
+): string {
+  let leftChar: string,
+    rightChar: string,
+    horizontalChar: string,
+    junctionChar: string;
+
+  switch (type) {
+    case "top": {
+      leftChar = borderChars.tl;
+      rightChar = borderChars.tr;
+      horizontalChar = borderChars.h;
+      junctionChar = borderChars.mt;
+      break;
+    }
+    case "middle": {
+      leftChar = borderChars.ml;
+      rightChar = borderChars.mr;
+      horizontalChar = borderChars.h;
+      junctionChar = borderChars.mc;
+      break;
+    }
+    case "bottom": {
+      leftChar = borderChars.bl;
+      rightChar = borderChars.br;
+      horizontalChar = borderChars.h;
+      junctionChar = borderChars.mb;
+      break;
+    }
+  }
+
+  const left = borderColorFn ? borderColorFn(leftChar) : leftChar;
+  const right = borderColorFn ? borderColorFn(rightChar) : rightChar;
+  const horizontal = borderColorFn
+    ? borderColorFn(horizontalChar)
+    : horizontalChar;
+  const junction = borderColorFn ? borderColorFn(junctionChar) : junctionChar;
+
+  const segments = widths.map((w) => horizontal.repeat(w));
+  return `${left}${segments.join(junction)}${right}`;
+}
+
+/**
+ * Assembles the final table string from rendered rows and border information.
+ * @param headerRow - The rendered header row string.
+ * @param contentRows - Array of rendered content row strings.
+ * @param columnWidths - Calculated widths for each column.
+ * @param border - Whether to draw a border.
+ * @param borderChars - Border characters to use.
+ * @param borderColorFn - Optional border color function to apply.
+ * @returns The final formatted table string.
+ */
+function _assembleTableOutput(
+  headerRow: string,
+  contentRows: string[],
+  columnWidths: number[],
+  border: boolean,
+  borderChars: TableBorderStyle,
+  borderColorFn?: (str: string) => string,
+): string {
+  if (!border) {
+    return [headerRow, ...contentRows].filter(Boolean).join("\n");
+  }
+
+  const topBorder = _createHorizontalLine(
+    columnWidths,
+    borderChars,
+    "top",
+    borderColorFn,
+  );
+  const bottomBorder = _createHorizontalLine(
+    columnWidths,
+    borderChars,
+    "bottom",
+    borderColorFn,
+  );
+  const separatorRow = _createHorizontalLine(
+    columnWidths,
+    borderChars,
+    "middle",
+    borderColorFn,
+  );
+
+  const tableLines: string[] = [topBorder];
+
+  if (headerRow) {
+    tableLines.push(headerRow);
+    if (contentRows.length > 0) {
+      tableLines.push(separatorRow);
+    }
+  }
+
+  for (let i = 0; i < contentRows.length; i++) {
+    tableLines.push(contentRows[i]);
+    if (i < contentRows.length - 1) {
+      tableLines.push(separatorRow);
+    }
+  }
+
+  tableLines.push(bottomBorder);
+
+  return tableLines.filter(Boolean).join("\n");
+}
+
+/**
+ * Creates a formatted string representation of a table from various data types.
+ * Supports arrays (of objects, arrays, or primitives) and objects (simple key-value or object-of-objects).
+ *
+ * @param data - The data to format as a table.
+ * @param columns - Optional array of column keys/headers to display. If omitted, all columns are shown.
+ * @param options - Optional settings for table appearance (style, padding, border, etc.).
+ * @returns The formatted table as a string, or an empty string if data is empty.
+ */
+export function createTable(
+  data: unknown,
+  columns?: string[] | null,
+  options: TableOptions = {},
+): string {
+  const {
+    tableStyle = { head: ["cyan"] },
+    padding = 1,
+    border = true,
+    borderColor,
+    borderStyle: userBorderStyle = "solid",
+  } = options;
+
+  // Resolve the border character set
+  const borderChars: TableBorderStyle =
+    typeof userBorderStyle === "string"
+      ? tableStylePresets[userBorderStyle] || tableStylePresets.solid
+      : (userBorderStyle ?? tableStylePresets.solid);
+
+  // Normalize data into headers and rows
+  const normalizedTable = normalizeTableData(data);
+
+  if (!normalizedTable) {
+    if (
+      data === null ||
+      data === undefined ||
+      (typeof data === "object" && Object.keys(data).length === 0) ||
+      (Array.isArray(data) && data.length === 0)
+    ) {
+      return "";
+    }
+    return String(data);
+  }
+
+  const originalHead = normalizedTable.head;
+  const originalRows = normalizedTable.rows;
+  let filteredHead = originalHead;
+  let filteredRows = originalRows;
+
+  // Apply column filtering
+  if (columns && columns.length > 0 && originalHead.length > 1) {
+    const originalHadIndex = originalHead[0] === "(index)";
+    const targetColumns = [...new Set(columns)];
+    if (originalHadIndex && !targetColumns.includes("(index)")) {
+      targetColumns.unshift("(index)");
+    }
+    const keptColumnIndices = targetColumns
+      .map((colName) => originalHead.indexOf(colName))
+      .filter((index) => index !== -1);
+    let finalIndices = [...keptColumnIndices];
+    if (originalHadIndex) {
+      const indexOfIndexInOriginal = originalHead.indexOf("(index)");
+      if (
+        indexOfIndexInOriginal !== -1 &&
+        !finalIndices.includes(indexOfIndexInOriginal)
+      ) {
+        finalIndices = [...new Set(finalIndices)].sort((a, b) => a - b);
+      }
+    }
+    if (finalIndices.length > 0) {
+      filteredHead = finalIndices.map((index) => originalHead[index] ?? "");
+      filteredRows = originalRows.map((row) =>
+        finalIndices.map((index) => row[index] ?? ""),
+      );
+    } else {
+      return "";
+    }
+  }
+
+  // Ensure rows match header length after filtering
+  filteredRows = normalizeTableRows(filteredHead, filteredRows);
+
+  // Calculate column widths based on filtered headers and rows
+  const columnWidths = _calculateColumnWidths(
+    filteredHead,
+    filteredRows,
+    padding,
+  );
+
+  // Prepare color functions based on options and assume colors are enabled
+  const headerColorName = tableStyle.head?.[0];
+  const headerColorFn = headerColorName ? colors[headerColorName] : undefined;
+  const borderColorFn = borderColor ? colors[borderColor] : undefined;
+
+  const { headerRow, contentRows } = _renderTableRows(
+    filteredHead,
+    filteredRows,
+    columnWidths,
+    padding,
+    options,
+    borderChars,
+    { header: headerColorFn, border: borderColorFn },
+  );
+
+  return _assembleTableOutput(
+    headerRow,
+    contentRows,
+    columnWidths,
+    border,
+    borderChars,
+    borderColorFn,
+  );
+}
+
+/**
+ * Normalizes the arguments for consola.table into a standard structure.
+ * Accepts the various overloads and returns { data, columns, options }.
+ * @param filterColumnsOrOptions - Optional columns array or options object.
+ * @param options - Optional options object (if filterColumnsOrOptions is columns array).
+ * @returns An object with normalized { data, columns, options }.
+ */
+export function parseTableArgs(
+  filterColumnsOrOptions?: string[] | object | null,
+  options?: object,
+): { filterColumns: string[] | null; options: Record<string, any> } {
+  let _columns: string[] | null = null;
+  let _options: Record<string, any> = {};
+
+  if (Array.isArray(filterColumnsOrOptions)) {
+    // Signature: table(data, columns[], options?)
+    _columns = filterColumnsOrOptions;
+    _options = options ?? {};
+  } else if (
+    typeof filterColumnsOrOptions === "object" &&
+    filterColumnsOrOptions !== null
+  ) {
+    // Signature: table(data, options)
+    _columns = null;
+    _options = filterColumnsOrOptions;
+  } else {
+    // Signature: table(data)
+    _columns = null;
+    _options = {};
+  }
+
+  return { filterColumns: _columns, options: _options };
+}

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,0 +1,951 @@
+import { describe, it, expect, vi } from "vitest";
+import { FancyReporter } from "../src/reporters/fancy";
+import { createConsola } from "../src";
+import { stripAnsi } from "../src/utils";
+import { BasicReporter } from "../src/reporters/basic";
+import { TableBorderStyle, TableOptions } from "../src/utils/table";
+
+const testData = [
+  { id: 1, name: "Alice", active: true, value: 123.45, notes: null },
+  {
+    id: 20,
+    name: "Joseph Lee Anson",
+    active: false,
+    value: -50,
+    notes: "Needs review",
+  },
+  { id: 303, name: "Charlie", active: true, value: 0, notes: undefined },
+  {
+    id: 4,
+    name: "David",
+    active: false,
+    value: 9999,
+    notes: "Long note example here",
+  },
+];
+
+describe("consola.table output with FancyReporter", () => {
+  it("should format array of objects with border (FancyReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+
+    consola.table(testData);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+
+    const expectedTable = [
+      "┌─────────┬─────┬──────────────────┬────────┬────────┬────────────────────────┐",
+      "│ (index) │ id  │ name             │ active │ value  │ notes                  │",
+      "├─────────┼─────┼──────────────────┼────────┼────────┼────────────────────────┤",
+      "│ 0       │ 1   │ Alice            │ true   │ 123.45 │ null                   │",
+      "├─────────┼─────┼──────────────────┼────────┼────────┼────────────────────────┤",
+      "│ 1       │ 20  │ Joseph Lee Anson │ false  │ -50    │ Needs review           │",
+      "├─────────┼─────┼──────────────────┼────────┼────────┼────────────────────────┤",
+      "│ 2       │ 303 │ Charlie          │ true   │ 0      │ undefined              │",
+      "├─────────┼─────┼──────────────────┼────────┼────────┼────────────────────────┤",
+      "│ 3       │ 4   │ David            │ false  │ 9999   │ Long note example here │",
+      "└─────────┴─────┴──────────────────┴────────┴────────┴────────────────────────┘",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should format object as Key/Value table with border (FancyReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data = {
+      name: "Charlie",
+      role: "Developer",
+    };
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "┌──────┬───────────┐",
+      "│ Key  │ Value     │",
+      "├──────┼───────────┤",
+      "│ name │ Charlie   │",
+      "├──────┼───────────┤",
+      "│ role │ Developer │",
+      "└──────┴───────────┘",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should return empty string for empty array (FancyReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data: unknown[] = [];
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    expect(outputString.trim()).toBe("");
+  });
+
+  it("should return empty string for empty object (FancyReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data = {};
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    expect(outputString.trim()).toBe("");
+  });
+
+  it("should return string input directly (FancyReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+
+    const data = "hello world";
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    expect(outputString.trim()).toBe("hello world");
+  });
+
+  it("should return number input directly (FancyReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data = 12_345;
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    expect(outputString.trim()).toBe("12345");
+  });
+
+  it("should render with 'double' border style preset", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data = { a: 1, b: 2 };
+
+    consola.table(data, { borderStyle: "double" });
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "╔═════╦═══════╗",
+      "║ Key ║ Value ║",
+      "╠═════╬═══════╣",
+      "║ a   ║ 1     ║",
+      "╠═════╬═══════╣",
+      "║ b   ║ 2     ║",
+      "╚═════╩═══════╝",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should render with 'rounded' border style preset", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data = { x: "yes" };
+
+    consola.table(data, { borderStyle: "rounded" });
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "╭─────┬───────╮",
+      "│ Key │ Value │",
+      "├─────┼───────┤",
+      "│ x   │ yes   │",
+      "╰─────┴───────╯",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should render with a custom BoxBorderStyle object (using default internal separators)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const customBorder: TableBorderStyle = {
+      tl: "*",
+      tr: "*",
+      bl: "*",
+      br: "*",
+      h: "=",
+      v: "!",
+      mc: "+",
+      mt: "*",
+      mb: "*",
+      ml: "!",
+      mr: "!",
+    };
+    const data = { val: 100 };
+    consola.table(data, { borderStyle: customBorder });
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "*=====*=======*",
+      "! Key ! Value !",
+      "!=====+=======!",
+      "! val ! 100   !",
+      "*=====*=======*",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should format array of strings", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data = ["apples", "oranges", "bananas"];
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "┌─────────┬─────────┐",
+      "│ (index) │ Value   │",
+      "├─────────┼─────────┤",
+      "│ 0       │ apples  │",
+      "├─────────┼─────────┤",
+      "│ 1       │ oranges │",
+      "├─────────┼─────────┤",
+      "│ 2       │ bananas │",
+      "└─────────┴─────────┘",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should format array of arrays", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const people = [
+      ["Tyrone", "Jones"],
+      ["Janet", "Smith"],
+      ["Maria", "Cruz"],
+    ];
+
+    consola.table(people);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "┌─────────┬────────┬───────┐",
+      "│ (index) │ 0      │ 1     │",
+      "├─────────┼────────┼───────┤",
+      "│ 0       │ Tyrone │ Jones │",
+      "├─────────┼────────┼───────┤",
+      "│ 1       │ Janet  │ Smith │",
+      "├─────────┼────────┼───────┤",
+      "│ 2       │ Maria  │ Cruz  │",
+      "└─────────┴────────┴───────┘",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should format object whose properties are objects", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+
+    function Person(firstName: string, lastName: string) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+    }
+
+    const family = {
+      mother: new Person("Janet", "Jones"),
+      father: new Person("Tyrone", "Kirby"),
+      daughter: new Person("Maria", "Dina"),
+    };
+
+    consola.table(family);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "┌──────────┬───────────┬──────────┐",
+      "│ (index)  │ firstName │ lastName │",
+      "├──────────┼───────────┼──────────┤",
+      "│ mother   │ Janet     │ Jones    │",
+      "├──────────┼───────────┼──────────┤",
+      "│ father   │ Tyrone    │ Kirby    │",
+      "├──────────┼───────────┼──────────┤",
+      "│ daughter │ Maria     │ Dina     │",
+      "└──────────┴───────────┴──────────┘",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should restrict columns displayed for array of objects", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+
+    function Person(firstName: string, lastName: string) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+    }
+
+    const tyrone = new Person("Tyrone", "Jones");
+    const janet = new Person("Janet", "Smith");
+    const maria = new Person("Maria", "Cruz");
+
+    consola.table([tyrone, janet, maria], ["firstName"]);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "┌─────────┬───────────┐",
+      "│ (index) │ firstName │",
+      "├─────────┼───────────┤",
+      "│ 0       │ Tyrone    │",
+      "├─────────┼───────────┤",
+      "│ 1       │ Janet     │",
+      "├─────────┼───────────┤",
+      "│ 2       │ Maria     │",
+      "└─────────┴───────────┘",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should restrict columns displayed for array of objects (using options object)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+
+    function Person(firstName: string, lastName: string, age: number) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.age = age;
+    }
+
+    const tyrone = new Person("Tyrone", "Jones", 30);
+    const janet = new Person("Janet", "Smith", 28);
+    const maria = new Person("Maria", "Cruz", 35);
+
+    consola.table([tyrone, janet, maria], ["lastName", "age"], {});
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "┌─────────┬──────────┬─────┐",
+      "│ (index) │ lastName │ age │",
+      "├─────────┼──────────┼─────┤",
+      "│ 0       │ Jones    │ 30  │",
+      "├─────────┼──────────┼─────┤",
+      "│ 1       │ Smith    │ 28  │",
+      "├─────────┼──────────┼─────┤",
+      "│ 2       │ Cruz     │ 35  │",
+      "└─────────┴──────────┴─────┘",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should render with custom padding: 0", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data = { a: 1, b: 2 };
+    consola.table(data, { padding: 0 });
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "┌───┬─────┐",
+      "│Key│Value│",
+      "├───┼─────┤",
+      "│a  │1    │",
+      "├───┼─────┤",
+      "│b  │2    │",
+      "└───┴─────┘",
+    ].join("\n");
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should render with custom padding: 2", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data = { a: 1 };
+    consola.table(data, { padding: 4 });
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "┌───────────┬─────────────┐",
+      "│    Key    │    Value    │",
+      "├───────────┼─────────────┤",
+      "│    a      │    1        │",
+      "└───────────┴─────────────┘",
+    ].join("\n");
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should render without border when border: false", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+    const data = { a: 1, b: 2 };
+    consola.table(data, { border: false });
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedOutput = ["Key   Value ", " a     1     ", " b     2"].join(
+      "\n",
+    );
+    expect(outputString.trim()).toBe(expectedOutput);
+  });
+
+  it("should render header text with specified color", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: true },
+    });
+    const data = { a: 1 };
+
+    consola.table(data, {
+      borderColor: "blue",
+      tableStyle: { head: ["green"] },
+    });
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+    const outputString = mockStdout.write.mock.calls[0][0];
+
+    const B = (char: string) => `\u001B[34m${char}\u001B[39m`;
+    const G = (text: string) => `\u001B[32m${text}\u001B[39m`;
+
+    const expectedTable = [
+      `${B("┌")}${B("─").repeat(5)}${B("┬")}${B("─").repeat(7)}${B("┐")}`,
+      `${B("│")} ${G("Key")} ${B("│")} ${G("Value")} ${B("│")}`,
+      `${B("├")}${B("─").repeat(5)}${B("┼")}${B("─").repeat(7)}${B("┤")}`,
+      `${B("│")} a   ${B("│")} 1     ${B("│")}`,
+      `${B("└")}${B("─").repeat(5)}${B("┴")}${B("─").repeat(7)}${B("┘")}`,
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+    expect(stripAnsi(outputString).trim()).toBe(
+      stripAnsi(expectedTable).trim(),
+    );
+  });
+
+  it("should restrict columns and apply options with 3 arguments", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: true },
+    });
+
+    function Person(firstName: string, lastName: string, age: number) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.age = age;
+    }
+
+    const data = [
+      new Person("Tyrone", "Jones", 30),
+      new Person("Janet", "Smith", 28),
+      new Person("Maria", "Cruz", 35),
+    ];
+
+    const columns = ["lastName", "age"];
+    const options: TableOptions = {
+      borderColor: "magenta",
+      tableStyle: { head: ["yellow"] },
+    };
+
+    consola.table(data, columns, options);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+    const outputString = mockStdout.write.mock.calls[0][0];
+
+    const M = (char: string) => `\u001B[35m${char}\u001B[39m`;
+    const Y = (text: string) => `\u001B[33m${text}\u001B[39m`;
+
+    const expectedTable = [
+      `${M("┌")}${M("─").repeat(9)}${M("┬")}${M("─").repeat(10)}${M("┬")}${M("─").repeat(5)}${M("┐")}`,
+      `${M("│")} ${Y("(index)")} ${M("│")} ${Y("lastName")} ${M("│")} ${Y("age")} ${M("│")}`,
+      `${M("├")}${M("─").repeat(9)}${M("┼")}${M("─").repeat(10)}${M("┼")}${M("─").repeat(5)}${M("┤")}`,
+      `${M("│")} 0       ${M("│")} Jones    ${M("│")} 30  ${M("│")}`,
+      `${M("├")}${M("─").repeat(9)}${M("┼")}${M("─").repeat(10)}${M("┼")}${M("─").repeat(5)}${M("┤")}`,
+      `${M("│")} 1       ${M("│")} Smith    ${M("│")} 28  ${M("│")}`,
+      `${M("├")}${M("─").repeat(9)}${M("┼")}${M("─").repeat(10)}${M("┼")}${M("─").repeat(5)}${M("┤")}`,
+      `${M("│")} 2       ${M("│")} Cruz     ${M("│")} 35  ${M("│")}`,
+      `${M("└")}${M("─").repeat(9)}${M("┴")}${M("─").repeat(10)}${M("┴")}${M("─").repeat(5)}${M("┘")}`,
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+    expect(stripAnsi(outputString).trim()).toBe(
+      stripAnsi(expectedTable).trim(),
+    );
+  });
+
+  it("should handle complex nested data structures", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new FancyReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+      formatOptions: { colors: false },
+    });
+
+    const complexData = [
+      {
+        id: 1,
+        user: { name: "Alice", role: "Admin" },
+        tags: ["system", "critical"],
+        metrics: { cpu: 0.95, memory: 1024, disk: null },
+        enabled: true,
+        timestamp: new Date("2023-01-15T10:00:00Z"),
+        settings: undefined,
+      },
+      {
+        id: 2,
+        user: { name: "Bob", role: "User" },
+        tags: ["data", "report", "long tag example"],
+        metrics: { cpu: 0.5, memory: 512, disk: 50.5 },
+        enabled: false,
+        timestamp: new Date("2023-01-16T12:30:00Z"),
+        settings: { theme: "dark", notifications: [1, 2] },
+      },
+      {
+        id: 3,
+        user: { name: "Charlie", role: "Guest" },
+        tags: [],
+        metrics: { cpu: Number.NaN, memory: Infinity },
+        enabled: true,
+        timestamp: new Date("2023-01-17T15:45:00Z"),
+        settings: { theme: "light" },
+      },
+    ];
+
+    consola.table(complexData);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+
+    const expectedTable = [
+      "┌─────────┬────┬──────┬──────────────────────────────┬─────────┬─────────┬───────────┬───────────┐",
+      "│ (index) │ id │ user │ tags                         │ metrics │ enabled │ timestamp │ settings  │",
+      "├─────────┼────┼──────┼──────────────────────────────┼─────────┼─────────┼───────────┼───────────┤",
+      "│ 0       │ 1  │ {…}  │ system,critical              │ {…}     │ true    │ {…}       │ undefined │",
+      "├─────────┼────┼──────┼──────────────────────────────┼─────────┼─────────┼───────────┼───────────┤",
+      "│ 1       │ 2  │ {…}  │ data,report,long tag example │ {…}     │ false   │ {…}       │ {…}       │",
+      "├─────────┼────┼──────┼──────────────────────────────┼─────────┼─────────┼───────────┼───────────┤",
+      "│ 2       │ 3  │ {…}  │                              │ {…}     │ true    │ {…}       │ {…}       │",
+      "└─────────┴────┴──────┴──────────────────────────────┴─────────┴─────────┴───────────┴───────────┘",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+});
+
+describe("consola.table output with BasicReporter", () => {
+  it("should format array of objects without border (BasicReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+
+    consola.table(testData);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "(index) | id  | name             | active | value  | notes                 ",
+      "--------|-----|------------------|--------|--------|-----------------------",
+      "0       | 1   | Alice            | true   | 123.45 | null                  ",
+      "1       | 20  | Joseph Lee Anson | false  | -50    | Needs review          ",
+      "2       | 303 | Charlie          | true   | 0      | undefined             ",
+      "3       | 4   | David            | false  | 9999   | Long note example here",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should format object as Key/Value table without border (BasicReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+    const data = {
+      name: "Charlie",
+      role: "Developer",
+      active: true,
+    };
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedOutput = [
+      "Key    | Value    ",
+      "-------|----------",
+      "name   | Charlie  ",
+      "role   | Developer",
+      "active | true",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedOutput);
+  });
+
+  it("should return empty string for empty array (BasicReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+    const data: unknown[] = [];
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    expect(outputString.trim()).toBe("");
+  });
+
+  it("should return empty string for empty object (BasicReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+    const data = {};
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    expect(outputString.trim()).toBe("");
+  });
+
+  it("should format simple array as Index/Value table without border (BasicReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+    const data = ["hey", "you", 123];
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedOutput = [
+      "(index) | Value",
+      "--------|------",
+      "0       | hey  ",
+      "1       | you  ",
+      "2       | 123",
+    ].join("\n");
+    expect(outputString.trim()).toBe(expectedOutput);
+  });
+
+  it("should return string input directly (BasicReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+    const data = "hello world";
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    expect(outputString.trim()).toBe("hello world");
+  });
+
+  it("should return number input directly (BasicReporter)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+    const data = 12_345;
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    expect(outputString.trim()).toBe("12345");
+  });
+
+  it("should format array of strings", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+    const data = ["apples", "oranges", "bananas"];
+
+    consola.table(data);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "(index) | Value  ",
+      "--------|--------",
+      "0       | apples ",
+      "1       | oranges",
+      "2       | bananas",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should format array of arrays", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+    const people = [
+      ["Tyrone", "Jones"],
+      ["Janet", "Smith"],
+      ["Maria", "Cruz"],
+    ];
+
+    consola.table(people);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "(index) | 0      | 1    ",
+      "--------|--------|------",
+      "0       | Tyrone | Jones",
+      "1       | Janet  | Smith",
+      "2       | Maria  | Cruz",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should format object whose properties are objects", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+
+    function Person(firstName: string, lastName: string) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+    }
+
+    const family = {
+      mother: new Person("Janet", "Jones"),
+      father: new Person("Tyrone", "Kirby"),
+      daughter: new Person("Maria", "Dina"),
+    };
+
+    consola.table(family);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "(index)  | firstName | lastName",
+      "---------|-----------|---------",
+      "mother   | Janet     | Jones   ",
+      "father   | Tyrone    | Kirby   ",
+      "daughter | Maria     | Dina",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should restrict columns displayed for array of objects", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+
+    function Person(firstName: string, lastName: string) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+    }
+    const tyrone = new Person("Tyrone", "Jones");
+    const janet = new Person("Janet", "Smith");
+    const maria = new Person("Maria", "Cruz");
+
+    consola.table([tyrone, janet, maria], ["firstName"]);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+    const expectedTable = [
+      "(index) | firstName | lastName",
+      "--------|-----------|---------",
+      "0       | Tyrone    | Jones   ",
+      "1       | Janet     | Smith   ",
+      "2       | Maria     | Cruz",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+
+  it("should restrict columns displayed for array of objects (using options object)", () => {
+    const mockStdout = { write: vi.fn() };
+    const consola = createConsola({
+      reporters: [new BasicReporter()],
+      stdout: mockStdout as any,
+      level: 5,
+    });
+
+    function Person(firstName: string, lastName: string, age: number) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.age = age;
+    }
+
+    const tyrone = new Person("Tyrone", "Jones", 30);
+    const janet = new Person("Janet", "Smith", 28);
+    const maria = new Person("Maria", "Cruz", 35);
+
+    consola.table([tyrone, janet, maria],  ["age", "lastName"]);
+
+    expect(mockStdout.write).toHaveBeenCalledOnce();
+
+    const outputString = stripAnsi(mockStdout.write.mock.calls[0][0]);
+
+    const expectedTable = [
+      "(index) | firstName | lastName | age",
+      "--------|-----------|----------|----",
+      "0       | Tyrone    | Jones    | 30 ",
+      "1       | Janet     | Smith    | 28 ",
+      "2       | Maria     | Cruz     | 35",
+    ].join("\n");
+
+    expect(outputString.trim()).toBe(expectedTable);
+  });
+});


### PR DESCRIPTION
This PR introduces a new table method, I chose to support the same api as the browser console.table(): https://developer.mozilla.org/en-US/docs/Web/API/console/table_static. The fancy styling is based around the same output as chrome.

Introduced additional settings for styling similar to the box in the fancy reporter and I've provided tests to try to cover all the possible scenarios.

**Features:**
- Can now use `.table(data)`,`.table(data, options?)`, `.table(data, columnFilters[], options?)`
- Supports custom column selection
- Allows customization of border style, border color, header color, and cell padding.
- Handles edge cases such as empty arrays/objects and primitive values gracefully.
- Integrates both Fancy and Basic reporters for styled or plain output.