### PR TITLE
fix!: corrects string width calculation considering emoji

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -1,11 +1,10 @@
-import _stringWidth from "string-width";
+import stringWidth from "string-width";
 import isUnicodeSupported from "is-unicode-supported";
 import { colors } from "../utils/color";
 import { parseStack } from "../utils/error";
 import { FormatOptions, LogObject } from "../types";
 import { LogLevel, LogType } from "../constants";
 import { BoxOpts, box } from "../utils/box";
-import { stripAnsi } from "../utils";
 import { BasicReporter } from "./basic";
 
 export const TYPE_COLOR_MAP: { [k in LogType]?: string } = {
@@ -36,15 +35,6 @@ const TYPE_ICONS: { [k in LogType]?: string } = {
   start: s("◐", "o"),
   log: "",
 };
-
-function stringWidth(str: string) {
-  // https://github.com/unjs/consola/issues/204
-  const hasICU = typeof Intl === "object";
-  if (!hasICU || !Intl.Segmenter) {
-    return stripAnsi(str).length;
-  }
-  return _stringWidth(str);
-}
 
 export class FancyReporter extends BasicReporter {
   formatStack(stack: string, message: string, opts?: FormatOptions) {

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,5 +1,5 @@
+import stringWidth from "string-width";
 import { getColor } from "./color";
-import { stripAnsi } from "./string";
 
 export type BoxBorderStyle = {
   /**
@@ -257,8 +257,8 @@ export function box(text: string, _opts: BoxOpts = {}) {
   const height = textLines.length + paddingOffset;
   const width =
     Math.max(
-      ...textLines.map((line) => stripAnsi(line).length),
-      opts.title ? stripAnsi(opts.title).length : 0,
+      ...textLines.map((line) => stringWidth(line)),
+      opts.title ? stringWidth(opts.title) : 0,
     ) + paddingOffset;
   const widthOffset = width + paddingOffset;
 
@@ -273,13 +273,10 @@ export function box(text: string, _opts: BoxOpts = {}) {
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
     const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
+      Math.floor((width - stringWidth(opts.title)) / 2),
     );
     const right = borderStyle.h.repeat(
-      width -
-        stripAnsi(opts.title).length -
-        stripAnsi(left).length +
-        paddingOffset,
+      width - stringWidth(opts.title) - stringWidth(left) + paddingOffset,
     );
     boxLines.push(
       `${leftSpace}${borderStyle.tl}${left}${title}${right}${borderStyle.tr}`,
@@ -312,7 +309,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
       // Text line
       const line = textLines[i - valignOffset];
       const left = " ".repeat(paddingOffset);
-      const right = " ".repeat(width - stripAnsi(line).length);
+      const right = " ".repeat(width - stringWidth(line));
       boxLines.push(
         `${leftSpace}${borderStyle.v}${left}${line}${right}${borderStyle.v}`,
       );

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect } from "vitest";
+import { align, box } from "../src/utils";
+
+describe("utils", () => {
+  test("can align string", () => {
+    const str = align("left", "F", 5, "-");
+    expect(str.length).toBe(5);
+    expect(str).toMatchInlineSnapshot(`"F----"`);
+
+    const str2 = align("left", "✅", 5, "-");
+    expect(str2.length).toBe(5);
+    expect(str2).toMatchInlineSnapshot(`"✅----"`);
+
+    const str3 = align("center", "F", 5, "-");
+    expect(str3.length).toBe(5);
+    expect(str3).toMatchInlineSnapshot(`"--F--"`);
+
+    const str4 = align("center", "✅", 5, "-");
+    expect(str4.length).toBe(5);
+    expect(str4).toMatchInlineSnapshot(`"--✅--"`);
+
+    const str5 = align("right", "F", 5, "-");
+    expect(str5.length).toBe(5);
+    expect(str5).toMatchInlineSnapshot(`"----F"`);
+
+    const str6 = align("right", "✅", 5, "-");
+    expect(str6.length).toBe(5);
+    expect(str6).toMatchInlineSnapshot(`"----✅"`);
+  });
+
+  test("render box string", () => {
+    const str = box("F");
+    expect(str).toMatchInlineSnapshot(`
+      "
+       ╭─────╮
+       │     │
+       │  F  │
+       │     │
+       ╰─────╯
+      "
+    `);
+
+    const str2 = box("✅");
+    expect(str2).toMatchInlineSnapshot(`
+      "
+       ╭──────╮
+       │      │
+       │  ✅  │
+       │      │
+       ╰──────╯
+      "
+    `);
+  });
+
+  test("render box string with custom options", () => {
+    const str = box("F", {
+      title: "B",
+      style: {
+        borderColor: "yellow",
+        borderStyle: {
+          tl: "╓",
+          tr: "╖",
+          bl: "╙",
+          br: "╜",
+          h: "═",
+          v: "║",
+        },
+      },
+    });
+    expect(str).toMatchInlineSnapshot(`
+      "
+       ╓═B═══╖
+       ║     ║
+       ║  F  ║
+       ║     ║
+       ╙═════╜
+      "
+    `);
+
+    const str2 = box("✅", {
+      title: "✅",
+      style: {
+        borderColor: "yellow",
+        borderStyle: {
+          tl: "╓",
+          tr: "╖",
+          bl: "╙",
+          br: "╜",
+          h: "═",
+          v: "║",
+        },
+      },
+    });
+    expect(str2).toMatchInlineSnapshot(`
+      "
+       ╓═✅═══╖
+       ║      ║
+       ║  ✅  ║
+       ║      ║
+       ╙══════╜
+      "
+    `);
+  });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { align, box } from "../src/utils";
 
 describe("utils", () => {
@@ -29,6 +29,8 @@ describe("utils", () => {
   });
 
   test("render box string", () => {
+    vi.stubEnv("CI", "true");
+
     const str = box("F");
     expect(str).toMatchInlineSnapshot(`
       "
@@ -53,6 +55,8 @@ describe("utils", () => {
   });
 
   test("render box string with custom options", () => {
+    vi.stubEnv("CI", "true");
+
     const str = box("F", {
       title: "B",
       style: {
@@ -80,7 +84,6 @@ describe("utils", () => {
     const str2 = box("✅", {
       title: "✅",
       style: {
-        borderColor: "yellow",
         borderStyle: {
           tl: "╓",
           tr: "╖",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect, vi } from "vitest";
-import { align, box } from "../src/utils";
+import { describe, test, expect } from "vitest";
+import { align, box, stripAnsi } from "../src/utils";
 
 describe("utils", () => {
   test("can align string", () => {
@@ -29,10 +29,8 @@ describe("utils", () => {
   });
 
   test("render box string", () => {
-    vi.stubEnv("CI", "true");
-
     const str = box("F");
-    expect(str).toMatchInlineSnapshot(`
+    expect(stripAnsi(str)).toMatchInlineSnapshot(`
       "
        ╭─────╮
        │     │
@@ -43,7 +41,7 @@ describe("utils", () => {
     `);
 
     const str2 = box("✅");
-    expect(str2).toMatchInlineSnapshot(`
+    expect(stripAnsi(str2)).toMatchInlineSnapshot(`
       "
        ╭──────╮
        │      │
@@ -55,8 +53,6 @@ describe("utils", () => {
   });
 
   test("render box string with custom options", () => {
-    vi.stubEnv("CI", "true");
-
     const str = box("F", {
       title: "B",
       style: {
@@ -71,7 +67,7 @@ describe("utils", () => {
         },
       },
     });
-    expect(str).toMatchInlineSnapshot(`
+    expect(stripAnsi(str)).toMatchInlineSnapshot(`
       "
        ╓═B═══╖
        ║     ║
@@ -94,7 +90,7 @@ describe("utils", () => {
         },
       },
     });
-    expect(str2).toMatchInlineSnapshot(`
+    expect(stripAnsi(str2)).toMatchInlineSnapshot(`
       "
        ╓═✅═══╖
        ║      ║


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
resolves https://github.com/unjs/consola/issues/402

❗❗ This drops fallback for `Intl` support for Node.js v14 (related to https://github.com/unjs/consola/issues/204#issuecomment-2559488457)