### PR TITLE
chore(types): omit `message`/`additional` from reporter's `logObj` param

### DIFF
--- a/src/consola.ts
+++ b/src/consola.ts
@@ -6,6 +6,7 @@ import type {
   InputLogObject,
   LogObject,
   ConsolaOptions,
+  ReportLogObj,
 } from "./types";
 import type { PromptOptions } from "./prompt";
 
@@ -23,7 +24,7 @@ export class Consola {
 
   _lastLog: {
     serialized?: string;
-    object?: LogObject;
+    object?: ReportLogObj;
     count?: number;
     time?: Date;
     timeout?: ReturnType<typeof setTimeout>;
@@ -408,8 +409,8 @@ export class Consola {
 
       // Log
       if (newLog) {
-        this._lastLog.object = logObj as LogObject;
-        this._log(logObj as LogObject);
+        this._lastLog.object = logObj as ReportLogObj;
+        this._log(logObj as ReportLogObj);
       }
     };
 
@@ -448,7 +449,7 @@ export class Consola {
     resolveLog(true);
   }
 
-  _log(logObj: LogObject) {
+  _log(logObj: ReportLogObj) {
     for (const reporter of this.options.reporters) {
       reporter.log(logObj, {
         options: this.options,

--- a/src/reporters/basic.ts
+++ b/src/reporters/basic.ts
@@ -1,6 +1,6 @@
 import { formatWithOptions } from "node:util";
 import type {
-  LogObject,
+  ReportLogObj,
   ConsolaReporter,
   FormatOptions,
   ConsolaOptions,
@@ -50,7 +50,7 @@ export class BasicReporter implements ConsolaReporter {
     return arr.filter(Boolean).join(" ");
   }
 
-  formatLogObj(logObj: LogObject, opts: FormatOptions) {
+  formatLogObj(logObj: ReportLogObj, opts: FormatOptions) {
     const message = this.formatArgs(logObj.args, opts);
 
     if (logObj.type === "box") {
@@ -75,7 +75,7 @@ export class BasicReporter implements ConsolaReporter {
     ]);
   }
 
-  log(logObj: LogObject, ctx: { options: ConsolaOptions }) {
+  log(logObj: ReportLogObj, ctx: { options: ConsolaOptions }) {
     const line = this.formatLogObj(logObj, {
       columns: (ctx.options.stdout as any).columns || 0,
       ...ctx.options.formatOptions,

--- a/src/reporters/browser.ts
+++ b/src/reporters/browser.ts
@@ -1,4 +1,4 @@
-import { LogObject } from "../types";
+import { ReportLogObj } from "../types";
 
 export class BrowserReporter {
   options: any;
@@ -30,7 +30,7 @@ export class BrowserReporter {
     return (console as any).__log || console.log;
   }
 
-  log(logObj: LogObject) {
+  log(logObj: ReportLogObj) {
     const consoleLogFn = this._getLogFn(logObj.level);
 
     // Type

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -2,7 +2,7 @@ import _stringWidth from "string-width";
 import isUnicodeSupported from "is-unicode-supported";
 import { colors } from "../utils/color";
 import { parseStack } from "../utils/error";
-import { FormatOptions, LogObject } from "../types";
+import { FormatOptions, ReportLogObj } from "../types";
 import { LogLevel, LogType } from "../constants";
 import { BoxOpts, box } from "../utils/box";
 import { stripAnsi } from "../utils";
@@ -63,7 +63,7 @@ export class FancyReporter extends BasicReporter {
     );
   }
 
-  formatType(logObj: LogObject, isBadge: boolean, opts: FormatOptions) {
+  formatType(logObj: ReportLogObj, isBadge: boolean, opts: FormatOptions) {
     const typeColor =
       (TYPE_COLOR_MAP as any)[logObj.type] ||
       (LEVEL_COLOR_MAP as any)[logObj.level] ||
@@ -83,7 +83,7 @@ export class FancyReporter extends BasicReporter {
     return _type ? getColor(typeColor)(_type) : "";
   }
 
-  formatLogObj(logObj: LogObject, opts: FormatOptions) {
+  formatLogObj(logObj: ReportLogObj, opts: FormatOptions) {
     const [message, ...additional] = this.formatArgs(logObj.args, opts).split(
       "\n",
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,14 +177,22 @@ export interface LogObject extends InputLogObject {
   [key: string]: unknown;
 }
 
+/**
+ * TS's built-in Omit type does not work well with "[key: string]: unknown;"
+ */
+type _Omit<T, Keys> = {
+  [key in keyof T as key extends Keys ? never : key]: T[key];
+};
+export type ReportLogObj = _Omit<LogObject, "message" | "additional">;
+
 export interface ConsolaReporter {
   /**
    * Defines how a log message is processed and displayed by this reporter.
-   * @param logObj The LogObject containing the log information to process. See {@link LogObject}.
+   * @param logObj The LogObject containing the log information to process. See {@link ReportLogObj}.
    * @param ctx An object containing context information such as options. See {@link ConsolaOptions}.
    */
   log: (
-    logObj: LogObject,
+    logObj: ReportLogObj,
     ctx: {
       options: ConsolaOptions;
     },

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from "vitest";
-import { ConsolaReporter, LogLevels, LogObject, createConsola } from "../src";
+import {
+  ConsolaReporter,
+  LogLevels,
+  ReportLogObj,
+  createConsola,
+} from "../src";
 
 describe("consola", () => {
   test("can set level", () => {
@@ -13,7 +18,7 @@ describe("consola", () => {
   });
 
   test("silent log level does't print logs", async () => {
-    const logs: LogObject[] = [];
+    const logs: ReportLogObj[] = [];
     const TestReporter: ConsolaReporter = {
       log(logObj) {
         logs.push(logObj);
@@ -35,7 +40,7 @@ describe("consola", () => {
   });
 
   test("can see spams without ending log", async () => {
-    const logs: LogObject[] = [];
+    const logs: ReportLogObj[] = [];
     const TestReporter: ConsolaReporter = {
       log(logObj) {
         logs.push(logObj);
@@ -58,7 +63,7 @@ describe("consola", () => {
   });
 });
 
-function wait(delay) {
+function wait(delay: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, delay);
   });


### PR DESCRIPTION
resolves https://github.com/unjs/consola/issues/406