### PR TITLE
fix(fancy): replace width-1 icons for start and trace to fix timestamp alignment

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -31,9 +31,9 @@ const TYPE_ICONS: { [k in LogType]?: string } = {
   info: s("ℹ", "i"),
   success: s("✔", "√"),
   debug: s("⚙", "D"),
-  trace: s("→", "→"),
+  trace: s("➡", "→"),
   fail: s("✖", "×"),
-  start: s("◐", "o"),
+  start: s("▶", "o"),
   log: "",
 };
 


### PR DESCRIPTION
Fixes #394

## Root Cause

The fancy reporter calculates timestamp alignment using `stringWidth(left)` where `left` includes the type icon. All type icons have a `string-width` of **2**:

| Type | Icon | `string-width` |
|------|------|----------------|
| error/fatal/fail | `✖` | 2 |
| ready/success | `✔` | 2 |
| warn | `⚠` | 2 |
| info | `ℹ` | 2 |
| debug | `⚙` | 2 |
| **start** | `◐` | **1** ← outlier |
| **trace** | `→` | **1** ← outlier |

Because `start` and `trace` icons have `string-width` 1 while every other type has 2, the `space` calculation in `formatLogObj` gives them one extra space — shifting their timestamp one character to the right.

## Fix

Replace the two outlier icons with ones that have `string-width` 2:

- `start`: `◐` (U+25D0, sw=1) → `▶` (U+25B6, sw=2) — play/run fits the semantic perfectly
- `trace`: `→` (U+2192, sw=1) → `➡` (U+27A1, sw=2) — same directional meaning

## Before / After

```
// Before
ℹ I am a info message              1:42:22 am
✔ I am a success message           1:42:22 am
◐ I am a start message              1:42:22 am  ← shifted right by 1
```

```
// After
ℹ I am a info message              1:48:11 am
✔ I am a success message           1:48:11 am
▶ I am a start message             1:48:11 am  ← aligned ✓
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual indicators in logs: trace entries now display with an arrow symbol (➡), and start entries with a play symbol (▶) when Unicode is supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->