### PR TITLE
fix(box): use string-width for correct emoji and CJK alignment

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -1,11 +1,10 @@
-import _stringWidth from "string-width";
 import isUnicodeSupported from "is-unicode-supported";
 import { colors } from "../utils/color";
 import { parseStack } from "../utils/error";
 import { FormatOptions, LogObject } from "../types";
 import { LogLevel, LogType } from "../constants";
 import { BoxOpts, box } from "../utils/box";
-import { stripAnsi } from "../utils";
+import { stripAnsi, stringWidth } from "../utils";
 import { BasicReporter } from "./basic";
 
 export const TYPE_COLOR_MAP: { [k in LogType]?: string } = {
@@ -36,15 +35,6 @@ const TYPE_ICONS: { [k in LogType]?: string } = {
   start: s("◐", "o"),
   log: "",
 };
-
-function stringWidth(str: string) {
-  // https://github.com/unjs/consola/issues/204
-  const hasICU = typeof Intl === "object";
-  if (!hasICU || !Intl.Segmenter) {
-    return stripAnsi(str).length;
-  }
-  return _stringWidth(str);
-}
 
 export class FancyReporter extends BasicReporter {
   formatStack(stack: string, message: string, opts?: FormatOptions) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ export * from "./utils/box";
 export * from "./utils/color";
 export {
   stripAnsi,
+  stringWidth,
   centerAlign,
   rightAlign,
   leftAlign,

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,5 +1,14 @@
+import _stringWidth from "string-width";
 import { getColor } from "./color";
 import { stripAnsi } from "./string";
+
+function stringWidth(str: string) {
+  const hasICU = typeof Intl === "object";
+  if (!hasICU || !Intl.Segmenter) {
+    return stripAnsi(str).length;
+  }
+  return _stringWidth(str);
+}
 
 export type BoxBorderStyle = {
   /**
@@ -257,8 +266,8 @@ export function box(text: string, _opts: BoxOpts = {}) {
   const height = textLines.length + paddingOffset;
   const width =
     Math.max(
-      ...textLines.map((line) => stripAnsi(line).length),
-      opts.title ? stripAnsi(opts.title).length : 0,
+      ...textLines.map((line) => stringWidth(line)),
+      opts.title ? stringWidth(opts.title) : 0,
     ) + paddingOffset;
   const widthOffset = width + paddingOffset;
 
@@ -273,13 +282,10 @@ export function box(text: string, _opts: BoxOpts = {}) {
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
     const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
+      Math.floor((width - stringWidth(opts.title)) / 2),
     );
     const right = borderStyle.h.repeat(
-      width -
-        stripAnsi(opts.title).length -
-        stripAnsi(left).length +
-        paddingOffset,
+      width - stringWidth(opts.title) - stripAnsi(left).length + paddingOffset,
     );
     boxLines.push(
       `${leftSpace}${borderStyle.tl}${left}${title}${right}${borderStyle.tr}`,
@@ -312,7 +318,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
       // Text line
       const line = textLines[i - valignOffset];
       const left = " ".repeat(paddingOffset);
-      const right = " ".repeat(width - stripAnsi(line).length);
+      const right = " ".repeat(width - stringWidth(line));
       boxLines.push(
         `${leftSpace}${borderStyle.v}${left}${line}${right}${borderStyle.v}`,
       );

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,14 +1,5 @@
-import _stringWidth from "string-width";
 import { getColor } from "./color";
-import { stripAnsi } from "./string";
-
-function stringWidth(str: string) {
-  const hasICU = typeof Intl === "object";
-  if (!hasICU || !Intl.Segmenter) {
-    return stripAnsi(str).length;
-  }
-  return _stringWidth(str);
-}
+import { stringWidth } from "./string";
 
 export type BoxBorderStyle = {
   /**
@@ -285,7 +276,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
       Math.floor((width - stringWidth(opts.title)) / 2),
     );
     const right = borderStyle.h.repeat(
-      width - stringWidth(opts.title) - stripAnsi(left).length + paddingOffset,
+      width - stringWidth(opts.title) - stringWidth(left) + paddingOffset,
     );
     boxLines.push(
       `${leftSpace}${borderStyle.tl}${left}${title}${right}${borderStyle.tr}`,

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,5 @@
+import _stringWidth from "string-width";
+
 const ansiRegex = [
   String.raw`[\u001B\u009B][[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d\/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d\/#&.:=?%@~_]*)*)?\u0007)`,
   String.raw`(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))`,
@@ -13,6 +15,23 @@ const ansiRegex = [
  */
 export function stripAnsi(text: string) {
   return text.replace(new RegExp(ansiRegex, "g"), "");
+}
+
+/**
+ * Calculates the visual width of a string in terminal columns, correctly handling
+ * emoji, CJK characters, and ANSI escape codes. Falls back to stripped ANSI length
+ * when `Intl.Segmenter` is not available.
+ *
+ * @param {string} str - The string to measure.
+ * @returns {number} The visual width of the string in terminal columns.
+ */
+export function stringWidth(str: string) {
+  // https://github.com/unjs/consola/issues/204
+  const hasICU = typeof Intl === "object";
+  if (!hasICU || !Intl.Segmenter) {
+    return stripAnsi(str).length;
+  }
+  return _stringWidth(str);
 }
 
 /**

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "vitest";
+import stringWidth from "string-width";
+import { box } from "../src/utils/box";
+
+describe("box", () => {
+  test("renders a basic box", () => {
+    const result = box("Hello");
+    const lines = result.split("\n").filter(Boolean);
+    const widths = lines.map((line) => stringWidth(line));
+    const uniqueWidths = [...new Set(widths)];
+    expect(uniqueWidths.length).toBe(1);
+  });
+
+  test("aligns box edges with emoji content", () => {
+    const result = box("Hello 🌍 World");
+    const lines = result.split("\n").filter(Boolean);
+    const widths = lines.map((line) => stringWidth(line));
+    const uniqueWidths = [...new Set(widths)];
+    expect(uniqueWidths.length).toBe(1);
+  });
+
+  test("aligns box edges with CJK characters", () => {
+    const result = box("こんにちは");
+    const lines = result.split("\n").filter(Boolean);
+    const widths = lines.map((line) => stringWidth(line));
+    const uniqueWidths = [...new Set(widths)];
+    expect(uniqueWidths.length).toBe(1);
+  });
+
+  test("aligns box edges with multiple emoji lines", () => {
+    const result = box("Line 1 🎉\nLine 2 🚀\nLine 3");
+    const lines = result.split("\n").filter(Boolean);
+    const widths = lines.map((line) => stringWidth(line));
+    const uniqueWidths = [...new Set(widths)];
+    expect(uniqueWidths.length).toBe(1);
+  });
+});

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -1,37 +1,40 @@
 import { describe, test, expect } from "vitest";
-import stringWidth from "string-width";
+import { stringWidth } from "../src/utils/string";
 import { box } from "../src/utils/box";
+
+function expectAlignedBox(result: string) {
+  const lines = result.split("\n").filter(Boolean);
+  const widths = lines.map((line) => stringWidth(line));
+  const uniqueWidths = [...new Set(widths)];
+  expect(uniqueWidths.length).toBe(1);
+}
 
 describe("box", () => {
   test("renders a basic box", () => {
-    const result = box("Hello");
-    const lines = result.split("\n").filter(Boolean);
-    const widths = lines.map((line) => stringWidth(line));
-    const uniqueWidths = [...new Set(widths)];
-    expect(uniqueWidths.length).toBe(1);
+    expectAlignedBox(box("Hello"));
   });
 
   test("aligns box edges with emoji content", () => {
-    const result = box("Hello 🌍 World");
-    const lines = result.split("\n").filter(Boolean);
-    const widths = lines.map((line) => stringWidth(line));
-    const uniqueWidths = [...new Set(widths)];
-    expect(uniqueWidths.length).toBe(1);
+    expectAlignedBox(box("Hello 🌍 World"));
   });
 
   test("aligns box edges with CJK characters", () => {
-    const result = box("こんにちは");
-    const lines = result.split("\n").filter(Boolean);
-    const widths = lines.map((line) => stringWidth(line));
-    const uniqueWidths = [...new Set(widths)];
-    expect(uniqueWidths.length).toBe(1);
+    expectAlignedBox(box("こんにちは"));
   });
 
   test("aligns box edges with multiple emoji lines", () => {
-    const result = box("Line 1 🎉\nLine 2 🚀\nLine 3");
-    const lines = result.split("\n").filter(Boolean);
-    const widths = lines.map((line) => stringWidth(line));
-    const uniqueWidths = [...new Set(widths)];
-    expect(uniqueWidths.length).toBe(1);
+    expectAlignedBox(box("Line 1 🎉\nLine 2 🚀\nLine 3"));
+  });
+
+  test("aligns box edges with emoji in title", () => {
+    expectAlignedBox(box("Content", { title: "🎉 Title" }));
+  });
+
+  test("aligns box edges with CJK title", () => {
+    expectAlignedBox(box("Content", { title: "タイトル" }));
+  });
+
+  test("aligns box edges with ZWJ emoji sequences", () => {
+    expectAlignedBox(box("Hello 👨‍👩‍👧 World"));
   });
 });


### PR DESCRIPTION
## What

Fixed `consola.box()` rendering misaligned right edges when content contains emoji or CJK (fullwidth) characters.

## Why

`stripAnsi(str).length` counts UTF-16 code units, not visual terminal columns. Emoji like 🌍 and CJK characters like 漢字 occupy 2 terminal columns but `.length` reports them as 1-2 code units, causing the right border to shift.

The `string-width` package (already a project dependency, used in `FancyReporter`) correctly calculates visual width using `Intl.Segmenter` when available.

## How

Replaced `stripAnsi(str).length` with a `stringWidth()` wrapper (same pattern as `FancyReporter`) in `src/utils/box.ts` for all width calculations:
- Content line width measurement
- Title width measurement
- Right-side padding calculation

Added tests in `test/box.test.ts` covering emoji, CJK, and multiline emoji content.

## Testing

- `pnpm vitest run` — all tests pass
- `pnpm lint` — passes
- Verified with emoji (🌍, 🎉, 🚀) and CJK (こんにちは) content

Fixes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved box and reporter width calculations to account for actual character display widths, fixing alignment issues with emoji, CJK, and other wide/ANSI-containing text.

* **Tests**
  * Added tests ensuring rendered boxes maintain consistent visual width across ASCII, emoji, CJK, and multi-line inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->