### PR TITLE
fix: calculate box width using display width

### DIFF
--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,5 +1,10 @@
+import _stringWidth from "string-width";
 import { getColor } from "./color";
 import { stripAnsi } from "./string";
+
+function stringWidth(str: string) {
+  return _stringWidth(stripAnsi(str));
+}
 
 export type BoxBorderStyle = {
   /**
@@ -255,11 +260,10 @@ export function box(text: string, _opts: BoxOpts = {}) {
   const paddingOffset =
     opts.style.padding % 2 === 0 ? opts.style.padding : opts.style.padding + 1;
   const height = textLines.length + paddingOffset;
+  const titleWidth = opts.title ? stringWidth(opts.title) : 0;
   const width =
-    Math.max(
-      ...textLines.map((line) => stripAnsi(line).length),
-      opts.title ? stripAnsi(opts.title).length : 0,
-    ) + paddingOffset;
+    Math.max(...textLines.map((line) => stringWidth(line)), titleWidth) +
+    paddingOffset;
   const widthOffset = width + paddingOffset;
 
   const leftSpace =
@@ -272,14 +276,9 @@ export function box(text: string, _opts: BoxOpts = {}) {
   // Include the title if it exists with borders
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
-    const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
-    );
+    const left = borderStyle.h.repeat(Math.floor((width - titleWidth) / 2));
     const right = borderStyle.h.repeat(
-      width -
-        stripAnsi(opts.title).length -
-        stripAnsi(left).length +
-        paddingOffset,
+      width - titleWidth - stringWidth(left) + paddingOffset,
     );
     boxLines.push(
       `${leftSpace}${borderStyle.tl}${left}${title}${right}${borderStyle.tr}`,
@@ -312,7 +311,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
       // Text line
       const line = textLines[i - valignOffset];
       const left = " ".repeat(paddingOffset);
-      const right = " ".repeat(width - stripAnsi(line).length);
+      const right = " ".repeat(width - stringWidth(line));
       boxLines.push(
         `${leftSpace}${borderStyle.v}${left}${line}${right}${borderStyle.v}`,
       );

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -1,0 +1,21 @@
+import stringWidth from "string-width";
+import { describe, expect, test } from "vitest";
+import { box } from "../src/utils/box";
+
+describe("box", () => {
+  test.each(["hello 🚀️ world", "漢字 test"])(
+    "keeps all rendered lines aligned for %s",
+    (text) => {
+      const lines = box(text, {
+        style: {
+          marginTop: 0,
+          marginBottom: 0,
+        },
+      }).split("\n");
+
+      const widths = lines.map((line) => stringWidth(line));
+
+      expect(widths.every((width) => width === widths[0])).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
resolves #402

`box()` currently uses `.length` when it calculates content/title width and the trailing padding for each line. That makes the content row narrower than the borders for wide glyphs such as `🚀️` and `漢字`.

This switches those calculations to display width via `string-width` and adds a regression test that checks all rendered box lines keep the same visible width for wide-character content.

Validation:
- pnpm test
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed box alignment for text containing special characters, formatting codes, and CJK/emoji content.

* **Tests**
  * Added test suite verifying consistent line alignment in box rendering output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->