### PR TITLE
fix: handle emoji sequences in stringWidth for correct box alignment

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ export * from "./utils/box";
 export * from "./utils/color";
 export {
   stripAnsi,
+  stringWidth,
   centerAlign,
   rightAlign,
   leftAlign,

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,5 +1,5 @@
 import { getColor } from "./color";
-import { stripAnsi } from "./string";
+import { stringWidth } from "./string";
 
 export type BoxBorderStyle = {
   /**
@@ -257,8 +257,8 @@ export function box(text: string, _opts: BoxOpts = {}) {
   const height = textLines.length + paddingOffset;
   const width =
     Math.max(
-      ...textLines.map((line) => stripAnsi(line).length),
-      opts.title ? stripAnsi(opts.title).length : 0,
+      ...textLines.map((line) => stringWidth(line)),
+      opts.title ? stringWidth(opts.title) : 0,
     ) + paddingOffset;
   const widthOffset = width + paddingOffset;
 
@@ -273,12 +273,12 @@ export function box(text: string, _opts: BoxOpts = {}) {
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
     const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
+      Math.floor((width - stringWidth(opts.title)) / 2),
     );
     const right = borderStyle.h.repeat(
       width -
-        stripAnsi(opts.title).length -
-        stripAnsi(left).length +
+        stringWidth(opts.title) -
+        stringWidth(left) +
         paddingOffset,
     );
     boxLines.push(
@@ -312,7 +312,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
       // Text line
       const line = textLines[i - valignOffset];
       const left = " ".repeat(paddingOffset);
-      const right = " ".repeat(width - stripAnsi(line).length);
+      const right = " ".repeat(width - stringWidth(line));
       boxLines.push(
         `${leftSpace}${borderStyle.v}${left}${line}${right}${borderStyle.v}`,
       );

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -13,32 +13,32 @@ const ansiRegex = [
 function isFullWidth(code: number): boolean {
   return (
     // CJK Unified Ideographs
-    (code >= 0x4e00 && code <= 0x9fff) ||
+    (code >= 0x4e_00 && code <= 0x9f_ff) ||
     // CJK Unified Ideographs Extension A
-    (code >= 0x3400 && code <= 0x4dbf) ||
+    (code >= 0x34_00 && code <= 0x4d_bf) ||
     // CJK Unified Ideographs Extension B-F
-    (code >= 0x20000 && code <= 0x2fa1f) ||
+    (code >= 0x2_00_00 && code <= 0x2_fa_1f) ||
     // CJK Compatibility Ideographs
-    (code >= 0xf900 && code <= 0xfaff) ||
+    (code >= 0xf9_00 && code <= 0xfa_ff) ||
     // CJK Compatibility Ideographs Supplement
-    (code >= 0x2f800 && code <= 0x2fa1f) ||
+    (code >= 0x2_f8_00 && code <= 0x2_fa_1f) ||
     // Hangul Syllables
-    (code >= 0xac00 && code <= 0xd7af) ||
+    (code >= 0xac_00 && code <= 0xd7_af) ||
     // Hangul Jamo Extended-B
-    (code >= 0xd7b0 && code <= 0xd7ff) ||
+    (code >= 0xd7_b0 && code <= 0xd7_ff) ||
     // Fullwidth Forms
-    (code >= 0xff01 && code <= 0xff60) ||
-    (code >= 0xffe0 && code <= 0xffe6) ||
+    (code >= 0xff_01 && code <= 0xff_60) ||
+    (code >= 0xff_e0 && code <= 0xff_e6) ||
     // Wide CJK punctuation
-    (code >= 0x3000 && code <= 0x303f) ||
+    (code >= 0x30_00 && code <= 0x30_3f) ||
     // Enclosed CJK Letters
-    (code >= 0x3200 && code <= 0x32ff) ||
+    (code >= 0x32_00 && code <= 0x32_ff) ||
     // CJK Compatibility
-    (code >= 0x3300 && code <= 0x33ff) ||
+    (code >= 0x33_00 && code <= 0x33_ff) ||
     // CJK Radicals Supplement
-    (code >= 0x2e80 && code <= 0x2eff) ||
+    (code >= 0x2e_80 && code <= 0x2e_ff) ||
     // Kangxi Radicals
-    (code >= 0x2f00 && code <= 0x2fdf)
+    (code >= 0x2f_00 && code <= 0x2f_df)
   );
 }
 
@@ -53,27 +53,27 @@ function isFullWidth(code: number): boolean {
 function isEmoji(code: number): boolean {
   return (
     // Emoticons
-    (code >= 0x1f600 && code <= 0x1f64f) ||
+    (code >= 0x1_f6_00 && code <= 0x1_f6_4f) ||
     // Misc Symbols and Pictographs
-    (code >= 0x1f300 && code <= 0x1f5ff) ||
+    (code >= 0x1_f3_00 && code <= 0x1_f5_ff) ||
     // Transport and Map Symbols
-    (code >= 0x1f680 && code <= 0x1f6ff) ||
+    (code >= 0x1_f6_80 && code <= 0x1_f6_ff) ||
     // Supplemental Symbols and Pictographs
-    (code >= 0x1f900 && code <= 0x1f9ff) ||
+    (code >= 0x1_f9_00 && code <= 0x1_f9_ff) ||
     // Symbols and Pictographs Extended-A
-    (code >= 0x1fa00 && code <= 0x1fa6f) ||
-    (code >= 0x1fa70 && code <= 0x1faff) ||
+    (code >= 0x1_fa_00 && code <= 0x1_fa_6f) ||
+    (code >= 0x1_fa_70 && code <= 0x1_fa_ff) ||
     // Misc Symbols
-    (code >= 0x2600 && code <= 0x26ff) ||
+    (code >= 0x26_00 && code <= 0x26_ff) ||
     // Dingbats
-    (code >= 0x2700 && code <= 0x27bf) ||
+    (code >= 0x27_00 && code <= 0x27_bf) ||
     // Enclosed Alphanumeric Supplement
-    (code >= 0x1f100 && code <= 0x1f1ff) ||
+    (code >= 0x1_f1_00 && code <= 0x1_f1_ff) ||
     // Flags
-    (code >= 0x1f1e6 && code <= 0x1f1ff) ||
+    (code >= 0x1_f1_e6 && code <= 0x1_f1_ff) ||
     // Playing card suits, chess symbols, etc.
-    code === 0x2640 ||
-    code === 0x2642
+    code === 0x26_40 ||
+    code === 0x26_42
   );
 }
 
@@ -86,20 +86,20 @@ function isEmoji(code: number): boolean {
 function isZeroWidth(code: number): boolean {
   return (
     // Combining characters (general range)
-    (code >= 0x0300 && code <= 0x036f) ||
+    (code >= 0x03_00 && code <= 0x03_6f) ||
     // Zero Width Space
-    code === 0x200b ||
+    code === 0x20_0b ||
     // Zero Width Non-Joiner
-    code === 0x200c ||
+    code === 0x20_0c ||
     // Zero Width Joiner
-    code === 0x200d ||
+    code === 0x20_0d ||
     // Word Joiner
-    code === 0x2060 ||
+    code === 0x20_60 ||
     // Combining characters from various blocks
-    (code >= 0x1ab0 && code <= 0x1aff) ||
-    (code >= 0x1dc0 && code <= 0x1dff) ||
-    (code >= 0x20d0 && code <= 0x20ff) ||
-    (code >= 0xfe20 && code <= 0xfe2f)
+    (code >= 0x1a_b0 && code <= 0x1a_ff) ||
+    (code >= 0x1d_c0 && code <= 0x1d_ff) ||
+    (code >= 0x20_d0 && code <= 0x20_ff) ||
+    (code >= 0xfe_20 && code <= 0xfe_2f)
   );
 }
 
@@ -110,7 +110,7 @@ function isZeroWidth(code: number): boolean {
  * @returns {boolean} True if the character is a skin tone modifier.
  */
 function isSkinToneModifier(code: number): boolean {
-  return code >= 0x1f3fb && code <= 0x1f3ff;
+  return code >= 0x1_f3_fb && code <= 0x1_f3_ff;
 }
 
 /**
@@ -120,7 +120,19 @@ function isSkinToneModifier(code: number): boolean {
  * @returns {boolean} True if the character is a regional indicator.
  */
 function isRegionalIndicator(code: number): boolean {
-  return code >= 0x1f1e6 && code <= 0x1f1ff;
+  return code >= 0x1_f1_e6 && code <= 0x1_f1_ff;
+}
+
+/**
+ * Checks if a Unicode code point is an emoji tag specifier.
+ * Tag specifiers (U+E0020..U+E007E) and CANCEL TAG (U+E007F) are used
+ * in emoji tag sequences, e.g. subdivision flags like 🏴󠁧󠁢󠁳󠁣󠁴󠁿.
+ *
+ * @param {number} code - The Unicode code point.
+ * @returns {boolean} True if the character is a tag specifier.
+ */
+function isTagSpecifier(code: number): boolean {
+  return code >= 0xe_00_20 && code <= 0xe_00_7f;
 }
 
 /**
@@ -138,7 +150,7 @@ export function stringWidth(text: string): number {
   let i = 0;
   while (i < stripped.length) {
     const code = stripped.codePointAt(i)!;
-    const charLen = code > 0xffff ? 2 : 1;
+    const charLen = code > 0xff_ff ? 2 : 1;
 
     // Skip zero-width characters
     if (isZeroWidth(code)) {
@@ -155,7 +167,7 @@ export function stringWidth(text: string): number {
       if (i < stripped.length) {
         const nextCode = stripped.codePointAt(i)!;
         if (isRegionalIndicator(nextCode)) {
-          i += nextCode > 0xffff ? 2 : 1;
+          i += nextCode > 0xff_ff ? 2 : 1;
         }
       }
       continue;
@@ -172,7 +184,7 @@ export function stringWidth(text: string): number {
       // - ZWJ + following emoji (family sequences like 👨‍👩‍👧‍👦)
       while (i < stripped.length) {
         const nextCode = stripped.codePointAt(i)!;
-        const nextCharLen = nextCode > 0xffff ? 2 : 1;
+        const nextCharLen = nextCode > 0xff_ff ? 2 : 1;
 
         // Skin tone modifier: zero-width, consume it
         if (isSkinToneModifier(nextCode)) {
@@ -181,20 +193,27 @@ export function stringWidth(text: string): number {
         }
 
         // Variation selector (emoji/text presentation): zero-width, consume it
-        if (nextCode >= 0xfe00 && nextCode <= 0xfe0f) {
+        if (nextCode >= 0xfe_00 && nextCode <= 0xfe_0f) {
           i += nextCharLen;
           continue;
         }
 
         // ZWJ: consume it, then consume the next emoji (which adds no extra width)
-        if (nextCode === 0x200d) {
+        if (nextCode === 0x20_0d) {
           i += nextCharLen; // consume ZWJ
           if (i < stripped.length) {
             const afterZWJ = stripped.codePointAt(i)!;
-            const afterZWJLen = afterZWJ > 0xffff ? 2 : 1;
+            const afterZWJLen = afterZWJ > 0xff_ff ? 2 : 1;
             i += afterZWJLen; // consume the emoji after ZWJ
             // Continue to check for more ZWJ sequences or modifiers
           }
+          continue;
+        }
+
+        // Emoji tag sequence (subdivision flags like 🏴󠁧󠁢󠁳󠁣󠁴󠁿)
+        // Tag specifiers U+E0020..U+E007F are zero-width
+        if (isTagSpecifier(nextCode)) {
+          i += nextCharLen;
           continue;
         }
 
@@ -203,11 +222,7 @@ export function stringWidth(text: string): number {
       continue;
     }
 
-    if (isFullWidth(code)) {
-      width += 2;
-    } else {
-      width += 1;
-    }
+    width += isFullWidth(code) ? 2 : 1;
     i += charLen;
   }
   return width;

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -95,6 +95,8 @@ function isZeroWidth(code: number): boolean {
     code === 0x20_0d ||
     // Word Joiner
     code === 0x20_60 ||
+    // Variation Selectors (emoji/text presentation)
+    (code >= 0xfe_00 && code <= 0xfe_0f) ||
     // Combining characters from various blocks
     (code >= 0x1a_b0 && code <= 0x1a_ff) ||
     (code >= 0x1d_c0 && code <= 0x1d_ff) ||

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -4,6 +4,216 @@ const ansiRegex = [
 ].join("|");
 
 /**
+ * Checks if a Unicode code point is a full-width character (occupies 2 columns in a terminal).
+ * Includes CJK ideographs, Hangul syllables, full-width forms, and wide punctuation.
+ *
+ * @param {number} code - The Unicode code point.
+ * @returns {boolean} True if the character is full-width.
+ */
+function isFullWidth(code: number): boolean {
+  return (
+    // CJK Unified Ideographs
+    (code >= 0x4e00 && code <= 0x9fff) ||
+    // CJK Unified Ideographs Extension A
+    (code >= 0x3400 && code <= 0x4dbf) ||
+    // CJK Unified Ideographs Extension B-F
+    (code >= 0x20000 && code <= 0x2fa1f) ||
+    // CJK Compatibility Ideographs
+    (code >= 0xf900 && code <= 0xfaff) ||
+    // CJK Compatibility Ideographs Supplement
+    (code >= 0x2f800 && code <= 0x2fa1f) ||
+    // Hangul Syllables
+    (code >= 0xac00 && code <= 0xd7af) ||
+    // Hangul Jamo Extended-B
+    (code >= 0xd7b0 && code <= 0xd7ff) ||
+    // Fullwidth Forms
+    (code >= 0xff01 && code <= 0xff60) ||
+    (code >= 0xffe0 && code <= 0xffe6) ||
+    // Wide CJK punctuation
+    (code >= 0x3000 && code <= 0x303f) ||
+    // Enclosed CJK Letters
+    (code >= 0x3200 && code <= 0x32ff) ||
+    // CJK Compatibility
+    (code >= 0x3300 && code <= 0x33ff) ||
+    // CJK Radicals Supplement
+    (code >= 0x2e80 && code <= 0x2eff) ||
+    // Kangxi Radicals
+    (code >= 0x2f00 && code <= 0x2fdf)
+  );
+}
+
+/**
+ * Checks if a Unicode code point is an emoji that occupies 2 columns in a terminal.
+ * This handles common emoji ranges using the Unicode property of characters
+ * that have the "Emoji_Presentation" property or are in known emoji ranges.
+ *
+ * @param {number} code - The Unicode code point.
+ * @returns {boolean} True if the character is an emoji.
+ */
+function isEmoji(code: number): boolean {
+  return (
+    // Emoticons
+    (code >= 0x1f600 && code <= 0x1f64f) ||
+    // Misc Symbols and Pictographs
+    (code >= 0x1f300 && code <= 0x1f5ff) ||
+    // Transport and Map Symbols
+    (code >= 0x1f680 && code <= 0x1f6ff) ||
+    // Supplemental Symbols and Pictographs
+    (code >= 0x1f900 && code <= 0x1f9ff) ||
+    // Symbols and Pictographs Extended-A
+    (code >= 0x1fa00 && code <= 0x1fa6f) ||
+    (code >= 0x1fa70 && code <= 0x1faff) ||
+    // Misc Symbols
+    (code >= 0x2600 && code <= 0x26ff) ||
+    // Dingbats
+    (code >= 0x2700 && code <= 0x27bf) ||
+    // Enclosed Alphanumeric Supplement
+    (code >= 0x1f100 && code <= 0x1f1ff) ||
+    // Flags
+    (code >= 0x1f1e6 && code <= 0x1f1ff) ||
+    // Playing card suits, chess symbols, etc.
+    code === 0x2640 ||
+    code === 0x2642
+  );
+}
+
+/**
+ * Checks if a Unicode code point is a zero-width character.
+ *
+ * @param {number} code - The Unicode code point.
+ * @returns {boolean} True if the character has zero width.
+ */
+function isZeroWidth(code: number): boolean {
+  return (
+    // Combining characters (general range)
+    (code >= 0x0300 && code <= 0x036f) ||
+    // Zero Width Space
+    code === 0x200b ||
+    // Zero Width Non-Joiner
+    code === 0x200c ||
+    // Zero Width Joiner
+    code === 0x200d ||
+    // Word Joiner
+    code === 0x2060 ||
+    // Combining characters from various blocks
+    (code >= 0x1ab0 && code <= 0x1aff) ||
+    (code >= 0x1dc0 && code <= 0x1dff) ||
+    (code >= 0x20d0 && code <= 0x20ff) ||
+    (code >= 0xfe20 && code <= 0xfe2f)
+  );
+}
+
+/**
+ * Checks if a Unicode code point is a skin tone modifier (Fitzpatrick scale).
+ *
+ * @param {number} code - The Unicode code point.
+ * @returns {boolean} True if the character is a skin tone modifier.
+ */
+function isSkinToneModifier(code: number): boolean {
+  return code >= 0x1f3fb && code <= 0x1f3ff;
+}
+
+/**
+ * Checks if a Unicode code point is a Regional Indicator Symbol (used for flag emojis).
+ *
+ * @param {number} code - The Unicode code point.
+ * @returns {boolean} True if the character is a regional indicator.
+ */
+function isRegionalIndicator(code: number): boolean {
+  return code >= 0x1f1e6 && code <= 0x1f1ff;
+}
+
+/**
+ * Calculates the display width of a string in terminal columns.
+ * Handles ANSI escape codes (0 width), emojis (2 columns),
+ * CJK full-width characters (2 columns), and zero-width characters (0 columns).
+ * Emoji sequences (ZWJ families, flags, skin tone modifiers) are counted as width 2.
+ *
+ * @param {string} text - The string to measure (may contain ANSI codes).
+ * @returns {number} The display width in terminal columns.
+ */
+export function stringWidth(text: string): number {
+  const stripped = stripAnsi(text);
+  let width = 0;
+  let i = 0;
+  while (i < stripped.length) {
+    const code = stripped.codePointAt(i)!;
+    const charLen = code > 0xffff ? 2 : 1;
+
+    // Skip zero-width characters
+    if (isZeroWidth(code)) {
+      i += charLen;
+      continue;
+    }
+
+    // Check for Regional Indicator pairs (flag emojis like 🇺🇸)
+    // Must check before general emoji since regional indicators overlap with emoji range
+    if (isRegionalIndicator(code)) {
+      width += 2;
+      i += charLen;
+      // Consume the second regional indicator if present
+      if (i < stripped.length) {
+        const nextCode = stripped.codePointAt(i)!;
+        if (isRegionalIndicator(nextCode)) {
+          i += nextCode > 0xffff ? 2 : 1;
+        }
+      }
+      continue;
+    }
+
+    // Check for emoji sequences
+    if (isEmoji(code)) {
+      width += 2;
+      i += charLen;
+
+      // Consume the rest of the emoji sequence:
+      // - Skin tone modifiers (Fitzpatrick scale)
+      // - Variation selectors
+      // - ZWJ + following emoji (family sequences like 👨‍👩‍👧‍👦)
+      while (i < stripped.length) {
+        const nextCode = stripped.codePointAt(i)!;
+        const nextCharLen = nextCode > 0xffff ? 2 : 1;
+
+        // Skin tone modifier: zero-width, consume it
+        if (isSkinToneModifier(nextCode)) {
+          i += nextCharLen;
+          continue;
+        }
+
+        // Variation selector (emoji/text presentation): zero-width, consume it
+        if (nextCode >= 0xfe00 && nextCode <= 0xfe0f) {
+          i += nextCharLen;
+          continue;
+        }
+
+        // ZWJ: consume it, then consume the next emoji (which adds no extra width)
+        if (nextCode === 0x200d) {
+          i += nextCharLen; // consume ZWJ
+          if (i < stripped.length) {
+            const afterZWJ = stripped.codePointAt(i)!;
+            const afterZWJLen = afterZWJ > 0xffff ? 2 : 1;
+            i += afterZWJLen; // consume the emoji after ZWJ
+            // Continue to check for more ZWJ sequences or modifiers
+          }
+          continue;
+        }
+
+        break; // Not part of the emoji sequence
+      }
+      continue;
+    }
+
+    if (isFullWidth(code)) {
+      width += 2;
+    } else {
+      width += 1;
+    }
+    i += charLen;
+  }
+  return width;
+}
+
+/**
  * Removes ANSI escape codes from a given string. This is particularly useful for
  * processing text that contains formatting codes, such as colours or styles, so that the
  * the raw text without any visual formatting.

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -175,6 +175,22 @@ export function stringWidth(text: string): number {
       continue;
     }
 
+    // Check for keycap sequences: base char + VARIATION SELECTOR-16 + COMBINING ENCLOSING KEYCAP
+    // e.g., 1️⃣ (#️⃣, *️⃣, etc.)
+    if (i + charLen < stripped.length) {
+      const vs16Code = stripped.codePointAt(i + charLen)!;
+      const vs16Len = vs16Code > 0xff_ff ? 2 : 1;
+      if (vs16Code === 0xfe_0f && i + charLen + vs16Len < stripped.length) {
+        const keycapCode = stripped.codePointAt(i + charLen + vs16Len)!;
+        const keycapLen = keycapCode > 0xff_ff ? 2 : 1;
+        if (keycapCode === 0x20_e3) {
+          width += 2;
+          i += charLen + vs16Len + keycapLen;
+          continue;
+        }
+      }
+    }
+
     // Check for emoji sequences
     if (isEmoji(code)) {
       width += 2;
@@ -203,11 +219,16 @@ export function stringWidth(text: string): number {
         // ZWJ: consume it, then consume the next emoji (which adds no extra width)
         if (nextCode === 0x20_0d) {
           i += nextCharLen; // consume ZWJ
+          // Only consume the next code point if it's an emoji-like character
+          // (emoji, skin tone modifier, variation selector, or regional indicator)
+          // Otherwise, the ZWJ is isolated and we should not swallow the following character
           if (i < stripped.length) {
             const afterZWJ = stripped.codePointAt(i)!;
-            const afterZWJLen = afterZWJ > 0xff_ff ? 2 : 1;
-            i += afterZWJLen; // consume the emoji after ZWJ
-            // Continue to check for more ZWJ sequences or modifiers
+            if (isEmoji(afterZWJ) || isSkinToneModifier(afterZWJ) || isRegionalIndicator(afterZWJ)) {
+              const afterZWJLen = afterZWJ > 0xff_ff ? 2 : 1;
+              i += afterZWJLen; // consume the emoji after ZWJ
+              // Continue to check for more ZWJ sequences or modifiers
+            }
           }
           continue;
         }

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -60,6 +60,30 @@ describe("stringWidth", () => {
     // Thumbs up with skin tone
     expect(stringWidth("👍🏿")).toBe(2);
   });
+
+  test("keycap emoji sequences count as width 2", () => {
+    // Keycap digit: 1️⃣ (1 + VS16 + combining enclosing keycap)
+    expect(stringWidth("1️⃣")).toBe(2);
+    // Keycap hash: #️⃣
+    expect(stringWidth("#️⃣")).toBe(2);
+    // Keycap asterisk: *️⃣
+    expect(stringWidth("*️⃣")).toBe(2);
+    // Keycap with surrounding text
+    expect(stringWidth("hello 1️⃣")).toBe(8); // 5 + 1 + 2
+    // Multiple keycaps
+    expect(stringWidth("1️⃣2️⃣")).toBe(4);
+  });
+
+  test("variation selectors outside emoji are zero-width", () => {
+    // Variation selector after regular char should not add width
+    expect(stringWidth("a\uFE0F")).toBe(1);
+    expect(stringWidth("a\uFE0Eb")).toBe(2);
+  });
+
+  test("ZWJ followed by non-emoji does not swallow it", () => {
+    // ZWJ + regular char: ZWJ should be zero-width, char should be counted
+    expect(stringWidth("a\u200Db")).toBe(2);
+  });
 });
 
 describe("box", () => {

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from "vitest";
+import { box, stringWidth } from "../src/utils";
+
+describe("stringWidth", () => {
+  test("regular ASCII characters", () => {
+    expect(stringWidth("hello")).toBe(5);
+    expect(stringWidth("")).toBe(0);
+  });
+
+  test("emoji counts as 2 columns", () => {
+    expect(stringWidth("😀")).toBe(2);
+    expect(stringWidth("hello 😀")).toBe(8); // 5 + 1 + 2
+  });
+
+  test("CJK characters count as 2 columns", () => {
+    expect(stringWidth("你")).toBe(2);
+    expect(stringWidth("hello 你")).toBe(8); // 5 + 1 + 2
+  });
+
+  test("ANSI escape codes have 0 width", () => {
+    const red = "\u001b[31mhello\u001b[39m";
+    expect(stringWidth(red)).toBe(5);
+  });
+
+  test("combined emoji and ANSI", () => {
+    const redEmoji = "\u001b[31m😀\u001b[39m";
+    expect(stringWidth(redEmoji)).toBe(2);
+  });
+
+  test("ZWJ emoji sequences count as width 2", () => {
+    // Family emoji: 👨‍👩‍👧‍👦 (man + ZWJ + woman + ZWJ + girl + ZWJ + boy)
+    expect(stringWidth("👨‍👩‍👧‍👦")).toBe(2);
+    expect(stringWidth("hello 👨‍👩‍👧‍👦")).toBe(8); // 5 + 1 + 2
+    // Couple emoji
+    expect(stringWidth("👩‍❤️‍👨")).toBe(2);
+  });
+
+  test("flag emoji sequences count as width 2", () => {
+    // US flag: 🇺🇸 (two regional indicators)
+    expect(stringWidth("🇺🇸")).toBe(2);
+    expect(stringWidth("hello 🇺🇸")).toBe(8); // 5 + 1 + 2
+    // Japan flag
+    expect(stringWidth("🇯🇵")).toBe(2);
+    // Multiple flags
+    expect(stringWidth("🇺🇸🇯🇵")).toBe(4);
+  });
+
+  test("emoji with skin tone modifiers count as width 2", () => {
+    // Waving hand with skin tone modifier
+    expect(stringWidth("👋🏽")).toBe(2);
+    expect(stringWidth("hello 👋🏽")).toBe(8); // 5 + 1 + 2
+    // Thumbs up with skin tone
+    expect(stringWidth("👍🏿")).toBe(2);
+  });
+});
+
+describe("box", () => {
+  test("box with emoji content has aligned right edge", () => {
+    const result = box("hello 😀", { style: { padding: 1 } });
+    const lines = result.split("\n");
+
+    // All content lines (between top and bottom border) should have the same visual width
+    const contentLines = lines.slice(1, -1);
+    const widths = contentLines.map((line) => stringWidth(line));
+
+    // All lines should have the same display width
+    expect(widths.every((w) => w === widths[0])).toBe(true);
+  });
+
+  test("box with mixed ASCII and emoji", () => {
+    const result = box("hi 😀\nbye", { style: { padding: 1 } });
+    const lines = result.split("\n");
+
+    // Check all lines have consistent display width (skip empty margin lines)
+    const contentLines = lines.filter((l) => l.length > 0);
+    const widths = contentLines.map((line) => stringWidth(line));
+    expect(widths.every((w) => w === widths[0])).toBe(true);
+  });
+
+  test("box with CJK characters has aligned edges", () => {
+    const result = box("你好世界", { style: { padding: 1 } });
+    const lines = result.split("\n");
+
+    const contentLines = lines.filter((l) => l.length > 0);
+    const widths = contentLines.map((line) => stringWidth(line));
+    expect(widths.every((w) => w === widths[0])).toBe(true);
+  });
+
+  test("box with emoji title has aligned edges", () => {
+    const result = box("content", {
+      title: "🎉 Title",
+      style: { padding: 1 },
+    });
+    const lines = result.split("\n");
+
+    const contentLines = lines.filter((l) => l.length > 0);
+    const widths = contentLines.map((line) => stringWidth(line));
+    expect(widths.every((w) => w === widths[0])).toBe(true);
+  });
+});

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -18,12 +18,12 @@ describe("stringWidth", () => {
   });
 
   test("ANSI escape codes have 0 width", () => {
-    const red = "\u001b[31mhello\u001b[39m";
+    const red = "\u001B[31mhello\u001B[39m";
     expect(stringWidth(red)).toBe(5);
   });
 
   test("combined emoji and ANSI", () => {
-    const redEmoji = "\u001b[31m😀\u001b[39m";
+    const redEmoji = "\u001B[31m😀\u001B[39m";
     expect(stringWidth(redEmoji)).toBe(2);
   });
 
@@ -43,6 +43,14 @@ describe("stringWidth", () => {
     expect(stringWidth("🇯🇵")).toBe(2);
     // Multiple flags
     expect(stringWidth("🇺🇸🇯🇵")).toBe(4);
+  });
+
+  test("subdivision flag emoji (tag sequences) count as width 2", () => {
+    // Scotland flag: 🏴󠁧󠁢󠁳󠁣󠁴󠁿 (black flag + tag specifiers + cancel tag)
+    expect(stringWidth("🏴󠁧󠁢󠁳󠁣󠁴󠁿")).toBe(2);
+    expect(stringWidth("hello 🏴󠁧󠁢󠁳󠁣󠁴󠁿")).toBe(8); // 5 + 1 + 2
+    // England flag
+    expect(stringWidth("🏴󠁧󠁢󠁥󠁮󠁧󠁿")).toBe(2);
   });
 
   test("emoji with skin tone modifiers count as width 2", () => {


### PR DESCRIPTION
## Problem

`stringWidth()` doesn't handle emoji sequences correctly, causing `box()` right edge to misalign:

- ZWJ sequences (👨‍👩‍👧‍👦): counts each emoji as width 2 → total 8 instead of 2
- Flag emojis (🇺🇸): counts each regional indicator as 2 → total 4 instead of 2
- Skin tone modifiers (👋🏽): not handled as zero-width modifiers

## Fix

Rewrite `stringWidth()` to consume entire emoji sequences:
- After detecting an emoji, consume skin tone modifiers (0x1f3fb–0x1f3ff), variation selectors (0xfe00–0xfe0f), and ZWJ+emoji pairs — all adding no extra width
- Regional indicator pairs (0x1f1e6–0x1f1ff) treated as single width-2 flag
- Removed variation selector range from `isEmoji()` to prevent false positives (variation selectors are handled in the sequence parser instead)

## Testing

Added `test/box.test.ts` with 12 tests covering:
- Basic ASCII, CJK, ANSI codes
- ZWJ family emoji (👨‍👩‍👧‍👦 → width 2)
- Flag emojis (🇺🇸 → width 2)
- Skin tone modifiers (👋🏽 → width 2)
- Box alignment with emoji content

All 15 tests pass.

Closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal-accurate string width calculation that handles Unicode, emoji (including ZWJ sequences and flags), CJK, and ignores ANSI escape sequences.
  * Improved box rendering and title alignment using display-width-aware measurements so multi-byte and emoji content aligns correctly across lines and borders.

* **Tests**
  * Comprehensive tests validating string width calculations and consistent box alignment across ASCII, CJK, emoji, and ANSI-containing strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->