### PR TITLE
fix(fancy): skip triple-backtick code fences in characterFormat

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -137,8 +137,8 @@ export class FancyReporter extends BasicReporter {
 function characterFormat(str: string) {
   return (
     str
-      // highlight backticks
-      .replace(/`([^`]+)`/gm, (_, m) => colors.cyan(m))
+      // highlight single backticks (skip code fences like ```)
+      .replace(/(?<!`)`(?!`)([^`]+)(?<!`)`(?!`)/gm, (_, m) => colors.cyan(m))
       // underline underscores
       .replace(/\s+_([^_]+)_\s+/gm, (_, m) => ` ${colors.underline(m)} `)
   );


### PR DESCRIPTION
Fixes #380

## Problem

The characterFormat function uses the regex ` /\([^\]+)\/gm ` to highlight single-backtick inline code in cyan. 

However, when a string contains triple-backtick code fences (e.g. \\\html ... \\\), the regex incorrectly matches across the fence — the third backtick of the opening \\\ becomes the opening delimiter, and the first backtick of the closing \\\ becomes the closing delimiter. This swallows the code block content and produces garbled / colored output.

## Fix

Use negative lookbehind and negative lookahead (` (?<!\) ` / ` (?!\) `) on both the opening and closing backtick so that only truly single backticks are matched:

\\\	s
// before
.replace(/\([^\]+)\/gm, (_, m) => colors.cyan(m))

// after
.replace(/(?<!\)\(?!\)([^\]+)(?<!\)\(?!\)/gm, (_, m) => colors.cyan(m))
\\\

Single-backtick inline code (e.g. \oo\) continues to be highlighted correctly. Triple-backtick fences are left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined backtick highlighting to properly differentiate between single-backtick inline code and multi-backtick code blocks, ensuring code fence markers are not incorrectly highlighted.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/consola/pull/418)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->