### PR TITLE
fix: resolve type incompatibility between consola and consola/core entry points

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -125,7 +125,7 @@ export type inferPromptReturnType<T extends PromptOptions> =
           ? T["options"]
           : unknown;
 
-export type inferPromptCancalReturnType<T extends PromptOptions> = T extends {
+export type inferPromptCancelReturnType<T extends PromptOptions> = T extends {
   cancel: "reject";
 }
   ? never
@@ -154,7 +154,7 @@ export async function prompt<
 >(
   message: string,
   opts: PromptOptions = {},
-): Promise<inferPromptReturnType<T> | inferPromptCancalReturnType<T>> {
+): Promise<inferPromptReturnType<T> | inferPromptCancelReturnType<T>> {
   const handleCancel = (value: unknown) => {
     if (
       typeof value !== "symbol" ||

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -112,7 +112,7 @@ export type PromptOptions =
   | SelectPromptOptions
   | MultiSelectOptions;
 
-type inferPromptReturnType<T extends PromptOptions> =
+export type inferPromptReturnType<T extends PromptOptions> =
   T extends TextPromptOptions
     ? string
     : T extends ConfirmPromptOptions
@@ -125,7 +125,7 @@ type inferPromptReturnType<T extends PromptOptions> =
           ? T["options"]
           : unknown;
 
-type inferPromptCancalReturnType<T extends PromptOptions> = T extends {
+export type inferPromptCancalReturnType<T extends PromptOptions> = T extends {
   cancel: "reject";
 }
   ? never

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,6 +2,7 @@ export { LogLevels, LogTypes } from "./constants";
 export { Consola } from "./consola";
 
 export type * from "./types";
+export type { PromptFunction } from "./types";
 export type { ConsolaInstance } from "./consola";
 export type { LogLevel, LogType } from "./constants";
 export type {
@@ -10,4 +11,6 @@ export type {
   MultiSelectOptions,
   SelectPromptOptions,
   TextPromptOptions,
+  inferPromptReturnType,
+  inferPromptCancalReturnType,
 } from "./prompt";

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -12,5 +12,5 @@ export type {
   SelectPromptOptions,
   TextPromptOptions,
   inferPromptReturnType,
-  inferPromptCancalReturnType,
+  inferPromptCancelReturnType,
 } from "./prompt";

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type {
   PromptOptions,
   TextPromptOptions,
   inferPromptReturnType,
-  inferPromptCancalReturnType,
+  inferPromptCancelReturnType,
 } from "./prompt";
 
 /**
@@ -15,7 +15,7 @@ import type {
 export type PromptFunction = <_ = any, __ = any, T extends PromptOptions = TextPromptOptions>(
   message: string,
   opts?: PromptOptions,
-) => Promise<inferPromptReturnType<T> | inferPromptCancalReturnType<T>>;
+) => Promise<inferPromptReturnType<T> | inferPromptCancelReturnType<T>>;
 
 export interface ConsolaOptions {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,21 @@
 import type { LogLevel, LogType } from "./constants";
+import type {
+  PromptOptions,
+  TextPromptOptions,
+  inferPromptReturnType,
+  inferPromptCancalReturnType,
+} from "./prompt";
+
+/**
+ * Type for the prompt function used in ConsolaOptions.
+ * Defined inline to avoid module-level type references that cause
+ * incompatibility between `consola` and `consola/core` entry points.
+ * @see https://github.com/unjs/consola/issues/382
+ */
+export type PromptFunction = <_ = any, __ = any, T extends PromptOptions = TextPromptOptions>(
+  message: string,
+  opts?: PromptOptions,
+) => Promise<inferPromptReturnType<T> | inferPromptCancalReturnType<T>>;
 
 export interface ConsolaOptions {
   /**
@@ -54,7 +71,7 @@ export interface ConsolaOptions {
    * Custom prompt function to use. It can be undefined.
    * @optional
    */
-  prompt?: typeof import("./prompt").prompt | undefined;
+  prompt?: PromptFunction | undefined;
 
   /**
    * Configuration options for formatting log messages. See {@link FormatOptions}.


### PR DESCRIPTION
## Problem

Types exported from `consola` and `consola/core` are incompatible. When importing `ConsolaInstance` from `consola/core` and assigning a value typed as `ConsolaInstance` from `consola`, TypeScript reports TS2719.

The root cause is that `ConsolaOptions.prompt` uses `typeof import("./prompt").prompt`, which creates a module-level type reference. When TypeScript resolves this from different entry points (`dist/index.d.mts` vs `dist/core.d.mts`), it treats them as different module instances even though they are structurally identical.

```ts
import { useLogger } from '@nuxt/kit'
import type { ConsolaInstance } from 'consola/core'

// TS2719: Type incompatibility
export const logger: ConsolaInstance = useLogger('nuxt:storybook')
```

## Fix

1. **Export `inferPromptReturnType` and `inferPromptCancalReturnType`** from `prompt.ts` so they can be imported by `types.ts`.

2. **Define `PromptFunction` type inline in `types.ts`** instead of using `typeof import("./prompt").prompt`. This ensures the type is defined once in a shared module and resolved consistently regardless of entry point.

3. **Re-export new types from `shared.ts`** for downstream consumers.

Fixes #382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved public typing around the prompt API, exporting previously internal helper types to make return-type inference more reliable and accessible.
* **Chores**
  * Added a named prompt function type and updated related configuration typing to simplify consumption of the prompt API by integrators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/consola/pull/419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->