### PR TITLE
fix: preserve message field for custom reporters

### DIFF
--- a/src/consola.ts
+++ b/src/consola.ts
@@ -373,7 +373,11 @@ export class Consola {
     // Aliases
     if (logObj.message) {
       logObj.args!.unshift(logObj.message);
-      delete logObj.message;
+    } else if (
+      logObj.args!.length > 0 &&
+      typeof logObj.args![0] === "string"
+    ) {
+      logObj.message = logObj.args![0];
     }
     if (logObj.additional) {
       if (!Array.isArray(logObj.additional)) {

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -34,6 +34,31 @@ describe("consola", () => {
     expect(logs.length).toBe(0);
   });
 
+  test("populates message for custom reporters", () => {
+    const logs: LogObject[] = [];
+    const TestReporter: ConsolaReporter = {
+      log(logObj) {
+        logs.push(logObj);
+      },
+    };
+
+    const consola = createConsola({
+      level: LogLevels.info,
+      reporters: [TestReporter],
+    });
+
+    consola.info("Test Message");
+    consola.info("Test Message with args", { arg1: "value1", arg2: 42 });
+
+    expect(logs[0]!.message).toBe("Test Message");
+    expect(logs[0]!.args).toEqual(["Test Message"]);
+    expect(logs[1]!.message).toBe("Test Message with args");
+    expect(logs[1]!.args).toEqual([
+      "Test Message with args",
+      { arg1: "value1", arg2: 42 },
+    ]);
+  });
+
   test("can see spams without ending log", async () => {
     const logs: LogObject[] = [];
     const TestReporter: ConsolaReporter = {


### PR DESCRIPTION
## Summary

- Custom reporters now receive a populated `logObj.message` when logging a string as the first argument
- Explicit `{ message: '...' }` log objects also keep `message` after args normalization

## Example

```ts
createConsola({
  reporters: [{
    log(logObj) {
      console.log(logObj.message); // "Test Message"
      console.log(logObj.args);    // ["Test Message"]
    },
  }],
}).info("Test Message");
```

Fixes #406

## Test plan

- [x] `pnpm exec vitest run` — 4 passing
- [x] Added regression test for string and string+object logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logger message handling: existing messages are preserved and plain-string arguments are promoted to the message when no message is present, preventing duplication or loss of content.

* **Tests**
  * Added test coverage to verify correct population of message and arguments for custom reporters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/consola/pull/423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->