### PR TITLE
feat(box): add titleAlign option for box title placement

### DIFF
--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -184,6 +184,12 @@ export type BoxStyle = {
    * @default 1
    */
   marginBottom: number;
+
+  /**
+   * Horizontal alignment of the title on the top border
+   * @default 'center'
+   */
+  titleAlign: "left" | "center" | "right";
 };
 
 /**
@@ -211,7 +217,37 @@ const defaultStyle: BoxStyle = {
   marginLeft: 1,
   marginTop: 1,
   marginBottom: 1,
+  titleAlign: "center",
 };
+
+function getTitleBorderPadding(
+  titleLength: number,
+  width: number,
+  paddingOffset: number,
+  titleAlign: BoxStyle["titleAlign"],
+) {
+  switch (titleAlign) {
+    case "left": {
+      return {
+        left: 0,
+        right: width - titleLength + paddingOffset,
+      };
+    }
+    case "right": {
+      return {
+        left: width - titleLength + paddingOffset,
+        right: 0,
+      };
+    }
+    default: {
+      const left = Math.floor((width - titleLength) / 2);
+      return {
+        left,
+        right: width - titleLength - left + paddingOffset,
+      };
+    }
+  }
+}
 
 /**
  * Creates a styled box with text content, customisable via options.
@@ -272,15 +308,15 @@ export function box(text: string, _opts: BoxOpts = {}) {
   // Include the title if it exists with borders
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
-    const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
+    const titleLength = stripAnsi(opts.title).length;
+    const { left: leftPadding, right: rightPadding } = getTitleBorderPadding(
+      titleLength,
+      width,
+      paddingOffset,
+      opts.style.titleAlign,
     );
-    const right = borderStyle.h.repeat(
-      width -
-        stripAnsi(opts.title).length -
-        stripAnsi(left).length +
-        paddingOffset,
-    );
+    const left = borderStyle.h.repeat(leftPadding);
+    const right = borderStyle.h.repeat(rightPadding);
     boxLines.push(
       `${leftSpace}${borderStyle.tl}${left}${title}${right}${borderStyle.tr}`,
     );

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { box } from "../src/utils/box";
+import { stripAnsi } from "../src/utils/string";
+
+const compactStyle = {
+  padding: 0,
+  marginLeft: 0,
+  marginTop: 0,
+  marginBottom: 0,
+  borderStyle: "solid" as const,
+};
+
+function topBorder(output: string) {
+  return stripAnsi(output.split("\n").find((line) => line.includes("┌")) || "");
+}
+
+describe("box", () => {
+  test.each([
+    ["center", "center", "┌───Warn────┐"],
+    ["left", "left", "┌Warn───────┐"],
+    ["right", "right", "┌───────Warn┐"],
+  ] as const)("aligns title to the %s", (_label, titleAlign, expectedTop) => {
+    const output = box("hello world", {
+      title: "Warn",
+      style: {
+        ...compactStyle,
+        titleAlign,
+      },
+    });
+
+    expect(topBorder(output)).toBe(expectedTop);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `style.titleAlign` with `"left" | "center" | "right"` (default `"center"`)
- Refactor top-border padding into `getTitleBorderPadding()` while preserving existing centered behavior

Fixes #389

## Usage

```ts
consola.box({
  title: "Warning",
  message: "Something happened",
  style: {
    titleAlign: "left",
    borderColor: "yellow",
  },
});
```

## Test plan

- [x] Added tests for left/center/right title alignment
- [x] `pnpm test`