### PR TITLE
refactor: use stripVTControlCharacters for stripAnsi on Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "vitest": "^3.0.9"
   },
   "engines": {
-    "node": "^14.18.0 || >=16.10.0"
+    "node": ">=16.11.0"
   },
   "packageManager": "pnpm@10.6.3"
 }

--- a/src/basic.ts
+++ b/src/basic.ts
@@ -1,3 +1,4 @@
+import "./utils/strip-ansi.node.ts";
 import { LogLevels, LogLevel } from "./constants";
 import type { ConsolaOptions } from "./types";
 import { BasicReporter } from "./reporters/basic";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { isDebug, isTest, isCI } from "std-env";
+import "./utils/strip-ansi.node.ts";
 import { LogLevels, LogLevel } from "./constants";
 import type { ConsolaOptions } from "./types";
 import { BasicReporter } from "./reporters/basic";

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -3,6 +3,22 @@ const ansiRegex = [
   String.raw`(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))`,
 ].join("|");
 
+const ansiPattern = new RegExp(ansiRegex, "g");
+
+let stripAnsiNative: ((text: string) => string) | undefined;
+
+/**
+ * Registers Node.js native VT stripping for {@link stripAnsi}.
+ * @internal
+ */
+export function setStripAnsiNative(fn: (text: string) => string) {
+  stripAnsiNative = fn;
+}
+
+function stripAnsiWithRegex(text: string) {
+  return text.replace(ansiPattern, "");
+}
+
 /**
  * Removes ANSI escape codes from a given string. This is particularly useful for
  * processing text that contains formatting codes, such as colours or styles, so that the
@@ -12,7 +28,7 @@ const ansiRegex = [
  * @returns {string} The text without ANSI escape codes.
  */
 export function stripAnsi(text: string) {
-  return text.replace(new RegExp(ansiRegex, "g"), "");
+  return stripAnsiNative ? stripAnsiNative(text) : stripAnsiWithRegex(text);
 }
 
 /**

--- a/src/utils/strip-ansi.node.ts
+++ b/src/utils/strip-ansi.node.ts
@@ -1,0 +1,5 @@
+import { stripVTControlCharacters } from "node:util";
+
+import { setStripAnsiNative } from "./string";
+
+setStripAnsiNative(stripVTControlCharacters);

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { colors } from "../src/utils/color";
+import { setStripAnsiNative, stripAnsi } from "../src/utils/string";
+import { stripVTControlCharacters } from "node:util";
+
+describe("stripAnsi", () => {
+  test("uses regex fallback when native stripping is not registered", () => {
+    setStripAnsiNative(undefined as unknown as typeof stripVTControlCharacters);
+    expect(stripAnsi(`${colors.red("hello")} world`)).toBe("hello world");
+  });
+
+  test("uses native VT stripping when registered", () => {
+    setStripAnsiNative(stripVTControlCharacters);
+    expect(stripAnsi(`${colors.green("ok")}`)).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary

- Register Node.js `stripVTControlCharacters` for `stripAnsi` via a node-only side-effect module
- Keep the existing regex implementation as fallback for browser and standalone `consola/utils` imports
- Bump `engines.node` to `>=16.11.0` (required by `stripVTControlCharacters`)

Fixes #377

## Test plan

- [x] Added tests for native and regex fallback paths
- [x] `pnpm test`