### PR TITLE
fix: align lazy prompt typing with consola/core

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,16 @@ import type { ConsolaOptions } from "./types";
 import { BasicReporter } from "./reporters/basic";
 import { FancyReporter } from "./reporters/fancy";
 import { ConsolaInstance, createConsola as _createConsola } from "./consola";
+import type { prompt as promptFn } from "./prompt";
 
 export * from "./shared";
+
+function createLazyPrompt(): NonNullable<ConsolaOptions["prompt"]> {
+  const lazyPrompt = ((message, opts) =>
+    import("./prompt").then((m) => m.prompt(message, opts))) as typeof promptFn;
+
+  return lazyPrompt;
+}
 
 /**
  * Factory function to create a new Consola instance tailored for use in different environments.
@@ -29,7 +37,7 @@ export function createConsola(
     defaults: { level },
     stdout: process.stdout,
     stderr: process.stderr,
-    prompt: (...args) => import("./prompt").then((m) => m.prompt(...args)),
+    prompt: createLazyPrompt(),
     reporters: options.reporters || [
       (options.fancy ?? !(isCI || isTest))
         ? new FancyReporter()

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./types-compat.test-d.ts"]
+}

--- a/test/types-compat.test-d.ts
+++ b/test/types-compat.test-d.ts
@@ -1,0 +1,7 @@
+import type { ConsolaInstance as CoreConsolaInstance } from "../src/consola";
+import { createConsola } from "../src/index";
+
+// Regression: https://github.com/unjs/consola/issues/382
+const logger: CoreConsolaInstance = createConsola();
+
+logger.info("ok");


### PR DESCRIPTION
## Summary

- Type the lazy-loaded `prompt` in `createConsola()` as `typeof prompt` so instances from the main entry match `ConsolaInstance` imported from `consola/core`
- Adds a regression type test for the assignment in #382

Closes #382

## Test plan

- [x] `pnpm test`
- [x] `npx tsc -p test/tsconfig.json`