### PR TITLE
fix(box): correct width calculation for emoji and CJK characters

### DIFF
--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,5 +1,5 @@
 import { getColor } from "./color";
-import { stripAnsi } from "./string";
+import { stripAnsi, visualWidth } from "./string";
 
 export type BoxBorderStyle = {
   /**
@@ -257,8 +257,8 @@ export function box(text: string, _opts: BoxOpts = {}) {
   const height = textLines.length + paddingOffset;
   const width =
     Math.max(
-      ...textLines.map((line) => stripAnsi(line).length),
-      opts.title ? stripAnsi(opts.title).length : 0,
+      ...textLines.map((line) => visualWidth(stripAnsi(line))),
+      opts.title ? visualWidth(stripAnsi(opts.title)) : 0,
     ) + paddingOffset;
   const widthOffset = width + paddingOffset;
 
@@ -273,11 +273,11 @@ export function box(text: string, _opts: BoxOpts = {}) {
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
     const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
+      Math.floor((width - visualWidth(stripAnsi(opts.title))) / 2),
     );
     const right = borderStyle.h.repeat(
       width -
-        stripAnsi(opts.title).length -
+        visualWidth(stripAnsi(opts.title)) -
         stripAnsi(left).length +
         paddingOffset,
     );
@@ -312,7 +312,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
       // Text line
       const line = textLines[i - valignOffset];
       const left = " ".repeat(paddingOffset);
-      const right = " ".repeat(width - stripAnsi(line).length);
+      const right = " ".repeat(width - visualWidth(stripAnsi(line)));
       boxLines.push(
         `${leftSpace}${borderStyle.v}${left}${line}${right}${borderStyle.v}`,
       );

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -107,3 +107,43 @@ export function align(
     }
   }
 }
+
+/**
+ * Calculates the visual display width of a string, accounting for wide characters
+ * such as CJK ideographs (Chinese, Japanese, Korean) and emoji.
+ *
+ * In most terminals, wide characters occupy 2 columns while regular characters
+ * occupy 1 column. This function uses Unicode range checks to determine width.
+ *
+ * @param {string} text - The text whose visual width to calculate.
+ * @returns {number} The visual width of the text in terminal columns.
+ */
+export function visualWidth(text: string) {
+  let width = 0;
+  for (const char of text) {
+    const code = char.codePointAt(0);
+    if (code === undefined) continue;
+    // Wide characters: CJK, Hangul, Katakana/Hiragana, emoji, etc.
+    if (
+      (code >= 0x1100 && code <= 0x115F) || // Hangul Jamo
+      (code >= 0x2E80 && code <= 0x303E) || // CJK Radicals / CJK Symbols
+      (code >= 0x3040 && code <= 0x33FF) || // Hiragana/Katakana/CJK Compat
+      (code >= 0x3400 && code <= 0x4DBF) || // CJK Unified Extension A
+      (code >= 0x4E00 && code <= 0x9FFF) || // CJK Unified
+      (code >= 0xA000 && code <= 0xA4CF) || // Yi
+      (code >= 0xAC00 && code <= 0xD7AF) || // Hangul Syllables
+      (code >= 0xF900 && code <= 0xFAFF) || // CJK Compatibility Ideographs
+      (code >= 0xFE10 && code <= 0xFE6F) || // Vertical Forms / CJK Compat Forms
+      (code >= 0xFF01 && code <= 0xFF60) || // Fullwidth Forms
+      (code >= 0xFFE0 && code <= 0xFFE6) || // Fullwidth Signs
+      (code >= 0x1F000 && code <= 0x1FFFF) || // Emoji supplement
+      (code >= 0x20000 && code <= 0x3FFFF) || // CJK Extension B+
+      code >= 0xE0100 // variation selectors supplement
+    ) {
+      width += 2;
+    } else {
+      width += 1;
+    }
+  }
+  return width;
+}


### PR DESCRIPTION
## Problem
`consola.box` misaligns when text contains emoji, CJK characters, or other wide Unicode characters (issue #402). The right edge of the box becomes misaligned because the width calculation uses `String.length`, which counts code units instead of visual column width.

## Changes
- **`src/utils/string.ts`**: add `visualWidth()` function that counts wide Unicode characters (CJK, Hangul, Katakana/Hiragana, emoji, etc.) as 2 columns instead of 1
- **`src/utils/box.ts`**: replace all `stripAnsi(...).length` calls used for visual width calculation with `visualWidth(stripAnsi(...))`

## Why
Terminal display width differs from JavaScript string length for Unicode characters. Using `visualWidth` ensures the box layout is correct regardless of the character set used.

## Testing
- Verified that `.length` vs visual width differs for emoji (🀄 = 2 columns) and CJK (汉字 = 4 columns)
- Existing tests continue to pass as they use ASCII-only content

Closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text width calculation for boxes to properly handle wide characters and special symbols, fixing box sizing and text alignment issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->