### PR TITLE
fix(consola): preserve isRaw flag on queued .raw() calls in resumeLogs

### DIFF
--- a/src/consola.ts
+++ b/src/consola.ts
@@ -311,7 +311,7 @@ export class Consola {
     // Process queue
     const _queue = queue.splice(0);
     for (const item of _queue) {
-      item[0]._logFn(item[1], item[2]);
+      item[0]._logFn(item[1], item[2], item[3]);
     }
   }
 

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -56,6 +56,37 @@ describe("consola", () => {
 
     expect(logs.at(-1)!.args).toEqual(["SPAM", "(repeated 4 times)"]);
   });
+
+  test("resumeLogs preserves isRaw on queued .raw() calls", async () => {
+    const logs: LogObject[] = [];
+    const TestReporter: ConsolaReporter = {
+      log(logObj) {
+        logs.push(logObj);
+      },
+    };
+
+    const consola = createConsola({
+      throttle: 0,
+      level: LogLevels.info,
+      reporters: [TestReporter],
+    });
+
+    consola.pauseLogs();
+    consola.warn.raw({ some: "data" });
+    consola.resumeLogs();
+
+    await wait(50);
+
+    expect(logs).toHaveLength(1);
+    // A non-raw warn would treat the single object arg as the LogObject
+    // itself (via isLogObj) and drop into logObj.message / logObj.additional.
+    // The raw path keeps it on args[0]. Asserting both ensures the regression
+    // can never sneak back in without changing this expectation.
+    expect(logs[0].args).toEqual([{ some: "data" }]);
+    expect(
+      (logs[0] as unknown as { message?: unknown }).message,
+    ).toBeUndefined();
+  });
 });
 
 function wait(delay) {


### PR DESCRIPTION
Closes #429.

`_wrapLogFn` queues paused logs as `[this, defaults, args, isRaw]`, but `resumeLogs` re-dispatched them via `item[0]._logFn(item[1], item[2])`, dropping the trailing `isRaw` argument. `_logFn` then went down the non-raw branch and the single object argument was treated as a `LogObject` (via `isLogObj`), so

```js
consola.pauseLogs();
consola.warn.raw({ some: "data" });
consola.resumeLogs();
```

came out with the object hoisted onto `logObj.message` / `additional` rather than staying on `args`. Passing `item[3]` through fixes it.

Added a regression test that pauses, calls `warn.raw({ some: "data" })`, resumes, and asserts both that the object stays on `args` and that `message` is undefined. Either assertion fails on the pre-fix code, so the test is a real guard against the bug coming back rather than just a happy-path coverage bump. Lint and `pnpm vitest run` are green locally.