### PR TITLE
feat(box): add titleAlign option to control title position

### DIFF
--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -184,6 +184,12 @@ export type BoxStyle = {
    * @default 1
    */
   marginBottom: number;
+
+  /**
+   * The horizontal alignment of the title
+   * @default 'center'
+   */
+  titleAlign: "left" | "center" | "right";
 };
 
 /**
@@ -211,6 +217,7 @@ const defaultStyle: BoxStyle = {
   marginLeft: 1,
   marginTop: 1,
   marginBottom: 1,
+  titleAlign: "center",
 };
 
 /**
@@ -272,15 +279,19 @@ export function box(text: string, _opts: BoxOpts = {}) {
   // Include the title if it exists with borders
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
-    const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
-    );
-    const right = borderStyle.h.repeat(
-      width -
-        stripAnsi(opts.title).length -
-        stripAnsi(left).length +
-        paddingOffset,
-    );
+    const titleLen = stripAnsi(opts.title).length;
+    const totalFill = width - titleLen + paddingOffset;
+    let leftCount: number;
+    if (opts.style.titleAlign === "left") {
+      leftCount = 0;
+    } else if (opts.style.titleAlign === "right") {
+      leftCount = totalFill;
+    } else {
+      leftCount = Math.floor(totalFill / 2);
+    }
+    const rightCount = totalFill - leftCount;
+    const left = borderStyle.h.repeat(leftCount);
+    const right = borderStyle.h.repeat(rightCount);
     boxLines.push(
       `${leftSpace}${borderStyle.tl}${left}${title}${right}${borderStyle.tr}`,
     );


### PR DESCRIPTION
The `box` utility always centers the title in the top border. This makes it impossible to left- or right-align the title without resorting to the workaround described in #389, where callers manually pad the title string with repeated border characters.

This change adds a `titleAlign` field to `BoxStyle` accepting `"left"`, `"center"`, or `"right"`. The default value is `"center"`, so existing call sites are unaffected. The rendering path that distributes fill characters (`h` repeated) on either side of the title now consults `titleAlign` to decide how to split that fill: zero on the left for `"left"`, all on the left for `"right"`, and the existing even split for `"center"`.

Closes #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new title alignment option for boxed text, allowing titles to be aligned left, center, or right.
  * Updated the default box styling to center titles by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->