### PR TITLE
fix: pass isRaw flag when resuming queued logs

### DIFF
--- a/src/consola.ts
+++ b/src/consola.ts
@@ -311,7 +311,7 @@ export class Consola {
     // Process queue
     const _queue = queue.splice(0);
     for (const item of _queue) {
-      item[0]._logFn(item[1], item[2]);
+      item[0]._logFn(item[1], item[2], item[3]);
     }
   }
 


### PR DESCRIPTION
## Problem

When using `pauseLogs()` and `resumeLogs()`, raw log calls queued during the paused state lose their `isRaw` flag when processed after resume.

```ts
consola.pauseLogs();
consola.warn.raw({ some: 'data' });
consola.resumeLogs();
// The queued raw(...) call gets processed without the isRaw flag
```

The queue stores `[this, defaults, args, isRaw]` but `resumeLogs()` only reads the first three elements.

## Fix

Pass `item[3]` (isRaw) to `_logFn()`:

```diff
  for (const item of _queue) {
-   item[0]._logFn(item[1], item[2]);
+   item[0]._logFn(item[1], item[2], item[3]);
  }
```

Fixes #429


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resumed queued logs now preserve their raw/formatted display state, so paused log output is replayed more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->