### PR TITLE
fix: preserve raw flag for queued logs

### DIFF
--- a/src/consola.ts
+++ b/src/consola.ts
@@ -311,7 +311,7 @@ export class Consola {
     // Process queue
     const _queue = queue.splice(0);
     for (const item of _queue) {
-      item[0]._logFn(item[1], item[2]);
+      item[0]._logFn(item[1], item[2], item[3]);
     }
   }
 

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -56,6 +56,27 @@ describe("consola", () => {
 
     expect(logs.at(-1)!.args).toEqual(["SPAM", "(repeated 4 times)"]);
   });
+
+  test("preserves raw logs queued while paused", () => {
+    const logs: LogObject[] = [];
+    const TestReporter: ConsolaReporter = {
+      log(logObj) {
+        logs.push(logObj);
+      },
+    };
+
+    const consola = createConsola({
+      level: LogLevels.info,
+      reporters: [TestReporter],
+    });
+
+    consola.pauseLogs();
+    consola.warn.raw({ message: "raw warning" });
+    consola.resumeLogs();
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].args).toEqual([{ message: "raw warning" }]);
+  });
 });
 
 function wait(delay) {


### PR DESCRIPTION
Fixes #429.

## Summary
- pass the queued raw flag back into _logFn when resumeLogs() drains paused logs
- add a regression test for a queued warn.raw(...) call so log-object-shaped arguments stay in args

## Validation
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed paused log replay so queued messages keep their full details when logging resumes.
  * Raw log entries are now preserved correctly after being queued during a pause.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->