### PR TITLE
fix: preserve markdown fences in fancy reporter

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -137,8 +137,8 @@ export class FancyReporter extends BasicReporter {
 function characterFormat(str: string) {
   return (
     str
-      // highlight backticks
-      .replace(/`([^`]+)`/gm, (_, m) => colors.cyan(m))
+      // Highlight inline code without consuming Markdown fence backticks.
+      .replace(/(?<!`)`([^`\n]+)`(?!`)/g, (_, m) => colors.cyan(m))
       // underline underscores
       .replace(/\s+_([^_]+)_\s+/gm, (_, m) => ` ${colors.underline(m)} `)
   );

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { ConsolaReporter, LogLevels, LogObject, createConsola } from "../src";
+import { FancyReporter } from "../src/reporters/fancy";
 
 describe("consola", () => {
   test("can set level", () => {
@@ -55,6 +56,30 @@ describe("consola", () => {
     // 6 + Last one indicating it repeated 4
 
     expect(logs.at(-1)!.args).toEqual(["SPAM", "(repeated 4 times)"]);
+  });
+
+  test("fancy reporter preserves markdown code fences", () => {
+    const reporter = new FancyReporter();
+    const message = [
+      "```html",
+      "<div>hello</div>",
+      "```",
+      "```html",
+      "<div>hello</div>",
+      "```",
+    ].join("\n");
+
+    const output = reporter.formatLogObj(
+      {
+        type: "log",
+        level: LogLevels.log,
+        date: new Date(),
+        args: [message],
+      },
+      {},
+    );
+
+    expect(output.match(/```html\n<div>hello<\/div>\n```/g)).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
Fixes #380.\n\n### What changed\n- Restrict inline backtick highlighting so it does not match across newlines or consume triple backticks from Markdown code fences.\n- Add a regression test that formats two adjacent fenced code blocks through the fancy reporter.\n\n### Validation\n- pnpm vitest run test/consola.test.ts\n- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline code highlighting so single backtick snippets are formatted correctly without interfering with fenced code blocks.
  * Preserved Markdown code fences in formatted log output, preventing fenced sections from being altered during display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->