### PR TITLE
fix: correct typos in test description and example string

### DIFF
--- a/examples/special.ts
+++ b/examples/special.ts
@@ -16,7 +16,7 @@ consola.error({ type: "CSSError", message: "Use scss" });
 
 consola.error(undefined, null, false, true, Number.NaN);
 
-consola.log("We can `monospace` keyword using grave accent charachter!");
+consola.log("We can `monospace` keyword using grave accent character!");
 
 consola.log(
   "We can also _underline_ words but not_this or this should_not_be_underlined!",

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -12,7 +12,7 @@ describe("consola", () => {
     }
   });
 
-  test("silent log level does't print logs", async () => {
+  test("silent log level doesn't print logs", async () => {
     const logs: LogObject[] = [];
     const TestReporter: ConsolaReporter = {
       log(logObj) {


### PR DESCRIPTION
## Summary

Fixed two typos in `.ts` source files:

- `test/consola.test.ts` line 15: `does't` -> `doesn't`
- `examples/special.ts` line 19: `charachter` -> `character`

Found with `codespell`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected example text to properly demonstrate the `monospace` keyword with a grave accent.
* **Tests**
  * Fixed a typo in a test description so the silent log level case reads correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->