### PR TITLE
fix: preserve raw flag when resuming logs

### DIFF
--- a/src/consola.ts
+++ b/src/consola.ts
@@ -311,7 +311,7 @@ export class Consola {
     // Process queue
     const _queue = queue.splice(0);
     for (const item of _queue) {
-      item[0]._logFn(item[1], item[2]);
+      item[0]._logFn(item[1], item[2], item[3]);
     }
   }
 

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -56,6 +56,30 @@ describe("consola", () => {
 
     expect(logs.at(-1)!.args).toEqual(["SPAM", "(repeated 4 times)"]);
   });
+
+  test("preserves raw arguments when queued logs are resumed", () => {
+    const logs: LogObject[] = [];
+    const consola = createConsola({
+      level: LogLevels.log,
+      reporters: [
+        {
+          log(logObj) {
+            logs.push(logObj);
+          },
+        },
+      ],
+    });
+
+    consola.log.raw({ message: "immediate" });
+    consola.pauseLogs();
+    consola.log.raw({ message: "queued" });
+    consola.resumeLogs();
+
+    expect(logs.map((log) => log.args)).toEqual([
+      [{ message: "immediate" }],
+      [{ message: "queued" }],
+    ]);
+  });
 });
 
 function wait(delay) {


### PR DESCRIPTION
## What changed

- forward the queued `isRaw` flag when `resumeLogs()` replays paused logs
- add regression coverage comparing immediate and queued raw log arguments

## Why

`_wrapLogFn` stores `isRaw` as the fourth queue item, but `resumeLogs()` previously passed only the first three values to `_logFn`. A raw object queued during `pauseLogs()` was therefore reinterpreted as a structured log object instead of remaining a raw argument.

Fixes #438.

## Checks

- ESLint across the repository
- Prettier check for `src`, `examples`, and `test`
- Vitest with V8 coverage: 4 tests passed
- `unbuild` production build

Prepared with Codex assistance; the issue, implementation, diff, and checks were reviewed locally.
