### PR TITLE
docs: prefer ConsolaInstance import from consola main entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ import { consola, createConsola } from "consola/browser";
 import { createConsola } from "consola/core";
 ```
 
+When typing values that come from the main `consola` entry (for example `useLogger()` from Nuxt kit), import types from `"consola"` — not `"consola/core"`. The `/core` build is a separate lightweight entry; its types are not always assignable to the main package types.
+
+```ts
+import type { ConsolaInstance } from "consola";
+```
+
 ## Consola Methods
 
 #### `<type>(logObject)` `<type>(args...)`


### PR DESCRIPTION
## Summary
- Document that `ConsolaInstance` (and other types for the main entry) should be imported from `consola`, not `consola/core`
- Helps avoid the type mismatch described in #382

Related to #382

## Test plan
- [ ] README guidance is clear next to the core/basic/browser import examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which package path to use when importing types from the main `consola` entry.
  * Noted that the lightweight `/core` entry has separate, potentially incompatible types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->