### PR TITLE
fix(fancy): replace width-1 icons for start and trace to fix timestamp alignment

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -31,9 +31,9 @@ const TYPE_ICONS: { [k in LogType]?: string } = {
   info: s("ℹ", "i"),
   success: s("✔", "√"),
   debug: s("⚙", "D"),
-  trace: s("→", "→"),
+  trace: s("➡", "→"),
   fail: s("✖", "×"),
-  start: s("◐", "o"),
+  start: s("▶", "o"),
   log: "",
 };
 


### PR DESCRIPTION
Fixes #394

## Root Cause
The fancy reporter calculates timestamp alignment using \stringWidth(left)\ where \left\ includes the type icon. All type icons have a \string-width\ of **2**:

| Type | Icon | \string-width\ |
|------|------|-----------------|
| error/fatal/fail | ✖ | 2 |
| ready/success | ✔ | 2 |
| warn | ⚠ | 2 |
| info | ℹ | 2 |
| debug | ⚙ | 2 |
| **start** | ◐ | **1** ← outlier |
| **trace** | → | **1** ← outlier |

Because \start\ and \	race\ icons have \string-width\ 1 while every other type has 2, the \space\ calculation in \ormatLogObj\ gives them one extra space — shifting their timestamp one character to the right.

## Fix
Replace the two outlier icons with ones that have \string-width\ 2:
- \start\: ◐ (U+25D0, sw=1) → ▶ (U+25B6, sw=2) — play/run fits the semantic perfectly
- \	race\: → (U+2192, sw=1) → ➡ (U+27A1, sw=2) — same directional meaning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual icons for trace and start log entries while preserving existing ASCII fallbacks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->