### PR TITLE
fix: use valid legacy types entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "main": "./lib/index.cjs",
   "module": "./dist/index.mjs",
   "browser": "./dist/browser.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
## What changed

- Point the legacy `types` field at the valid ESM declaration generated as `dist/index.d.mts`.
- Keep the conditional CommonJS type entry on `dist/index.d.cts` for `require` consumers.

## Why

The generated `dist/index.d.ts` combines `export =` with named exports behind `@ts-ignore`. Legacy directory resolution reaches that file through the top-level `types` field, and TypeScript 7 reports TS2595 at named-import sites. Using the valid declaration entry removes the consumer error without changing runtime exports.

Fixes #441.

## Checks

- `pnpm build`
- `eslint .`
- `prettier -c package.json`
- `vitest run --coverage` (3 tests passed)
- TypeScript 5.8 consumer compile with a directory `paths` mapping
- `@typescript/native-preview` / tsgo consumer compile