### PR TITLE
feat: add box title alignment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ consola.warn("A new version of consola is available: 3.0.1");
 consola.success("Project built!");
 consola.error(new Error("This is an example error. Everything is fine!"));
 consola.box("I am a simple box");
+consola.box({
+  title: "Notice",
+  titleAlign: "left",
+  message: "I am a box with a left-aligned title",
+});
 await consola.prompt("Deploy to the production?", {
   type: "confirm",
 });

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -97,6 +97,7 @@ export class FancyReporter extends BasicReporter {
           title: logObj.title
             ? characterFormat(logObj.title as string)
             : undefined,
+          titleAlign: logObj.titleAlign as BoxOpts["titleAlign"],
           style: logObj.style as BoxOpts["style"],
         },
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,12 @@ export interface InputLogObject {
   message?: string;
 
   /**
+   * The horizontal alignment of the box title.
+   * @optional
+   */
+  titleAlign?: "left" | "center" | "right";
+
+  /**
    * Additional text or texts to be logged with the message.
    * @optional
    */

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -197,6 +197,12 @@ export type BoxOpts = {
    */
   title?: string;
 
+  /**
+   * The horizontal alignment of the title
+   * @default 'center'
+   */
+  titleAlign?: "left" | "center" | "right";
+
   style?: Partial<BoxStyle>;
 };
 
@@ -272,15 +278,17 @@ export function box(text: string, _opts: BoxOpts = {}) {
   // Include the title if it exists with borders
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
-    const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
-    );
-    const right = borderStyle.h.repeat(
-      width -
-        stripAnsi(opts.title).length -
-        stripAnsi(left).length +
-        paddingOffset,
-    );
+    const titleWidth = stripAnsi(opts.title).length;
+    const availableWidth = width - titleWidth + paddingOffset;
+    let leftWidth = Math.floor((width - titleWidth) / 2);
+    if (opts.titleAlign === "left") {
+      leftWidth = 0;
+    } else if (opts.titleAlign === "right") {
+      leftWidth = availableWidth;
+    }
+    const rightWidth = availableWidth - leftWidth;
+    const left = borderStyle.h.repeat(leftWidth);
+    const right = borderStyle.h.repeat(rightWidth);
     boxLines.push(
       `${leftSpace}${borderStyle.tl}${left}${title}${right}${borderStyle.tr}`,
     );

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { box, stripAnsi } from "../src/utils";
+
+describe("box", () => {
+  test("aligns the title to the center by default", () => {
+    const output = box("hello", {
+      title: "Title",
+      style: {
+        borderColor: undefined,
+      },
+    });
+
+    expect(stripAnsi(output).split("\n")[1]).toBe(" ╭─Title───╮");
+  });
+
+  test("can align the title to the left", () => {
+    const output = box("hello", {
+      title: "Title",
+      titleAlign: "left",
+      style: {
+        borderColor: undefined,
+      },
+    });
+
+    expect(stripAnsi(output).split("\n")[1]).toBe(" ╭Title────╮");
+  });
+
+  test("can align the title to the right", () => {
+    const output = box("hello", {
+      title: "Title",
+      titleAlign: "right",
+      style: {
+        borderColor: undefined,
+      },
+    });
+
+    expect(stripAnsi(output).split("\n")[1]).toBe(" ╭────Title╮");
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Add a `titleAlign` option to box logs with `left`, `center`, and `right` values.
- Pass `titleAlign` through the fancy reporter so `consola.box({ titleAlign })` works.
- Document the option in the README and cover the alignment modes with tests.

Fixes #389.

## Tests

- `node node_modules/vitest/vitest.mjs run`
- `node_modules/.bin/eslint .`
- `node_modules/.bin/unbuild`
- `git diff --check`

Note: `pnpm install` completed dependency installation, but this pnpm version returned `ERR_PNPM_IGNORED_BUILDS` because local build-script approval is required for esbuild. The verification commands above were run directly through the installed local binaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for left-, center-, or right-aligned titles in boxed log output.
  * Box title borders now adjust automatically based on the selected alignment.
  * Updated the Getting Started example to demonstrate box options.

* **Tests**
  * Added coverage for default, left, and right title alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->