### PR TITLE
fix(fancy): align right-side content across log types

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -113,8 +113,24 @@ export class FancyReporter extends BasicReporter {
     let line;
     const left = this.filterAndJoin([type, characterFormat(message)]);
     const right = this.filterAndJoin(opts.columns ? [tag, coloredDate] : [tag]);
+
+    // string-width reports some consola icons (ℹ ✔ ✖ ⚠) as width 2
+    // (East Asian Ambiguous) but they render as width 1 in most terminals.
+    // Other icons (◐ →) are correctly reported as width 1. This inconsistency
+    // causes the right-aligned date/tag to be misaligned between log types.
+    // Correct the discrepancy by subtracting the overestimate.
+    // https://github.com/unjs/consola/issues/394
+    const typeStripped = stripAnsi(type);
+    const iconWidthDiff = typeStripped
+      ? stringWidth(typeStripped) - typeStripped.length
+      : 0;
+
     const space =
-      (opts.columns || 0) - stringWidth(left) - stringWidth(right) - 2;
+      (opts.columns || 0) -
+      stringWidth(left) -
+      stringWidth(right) -
+      2 +
+      iconWidthDiff;
 
     line =
       space > 0 && (opts.columns || 0) >= 80

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { ConsolaReporter, LogLevels, LogObject, createConsola } from "../src";
+import { FancyReporter } from "../src/reporters/fancy";
+import { stripAnsi } from "../src/utils/string";
 
 describe("consola", () => {
   test("can set level", () => {
@@ -55,6 +57,31 @@ describe("consola", () => {
     // 6 + Last one indicating it repeated 4
 
     expect(logs.at(-1)!.args).toEqual(["SPAM", "(repeated 4 times)"]);
+  });
+
+  test("fancy reporter aligns right-side content across log types (#394)", () => {
+    const reporter = new FancyReporter();
+    const opts = { columns: 120, date: true };
+
+    const lines = ["info", "success", "start"].map((type) => {
+      const logObj: LogObject = {
+        type,
+        level: 3,
+        tag: "",
+        args: ["test message"],
+        date: new Date("2025-01-01T00:00:00.000Z"),
+      } as any;
+      return reporter.formatLogObj(logObj, opts as any);
+    });
+
+    // Extract the position of the date string in each line
+    const positions = lines.map((line) => {
+      return stripAnsi(line).lastIndexOf("12:00:00 AM");
+    });
+
+    // All positions must be equal (right-aligned)
+    expect(positions[0]).toBe(positions[1]);
+    expect(positions[1]).toBe(positions[2]);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #394.

The `start` method's time label was misaligned by 1 character compared to `info` and `success`.

### Root cause

`string-width` reports consola's icon characters inconsistently:

| Icon | Character | `stringWidth` | Actual terminal width |
|------|-----------|--------------|----------------------|
| info | `ℹ` U+2139 | **2** | 1 |
| success | `✔` U+2714 | **2** | 1 |
| start | `◐` U+25D0 | **1** | 1 |
| error | `✖` U+2716 | **2** | 1 |
| warn | `⚠` U+26A0 | **2** | 1 |

`ℹ` and `✔` are classified as East Asian Ambiguous (width 2 by `string-width`), but `◐` is classified as width 1. All render as width 1 in most Western terminals.

The `space` calculation in `formatLogObj` uses `stringWidth(left)` to right-align the date/tag. When the icon is overestimated as width 2, `space` is 1 less than it should be, pushing the date 1 char too far left. Since `info` and `success` are both overestimated by the same amount, they look aligned with each other — but `start` (correctly estimated) looks misaligned.

### Fix

Calculate the icon width discrepancy (`stringWidth(icon) - icon.length`) and compensate in the `space` calculation. This normalizes all icons to their actual terminal display width without changing the icons themselves.

```typescript
const typeStripped = stripAnsi(type);
const iconWidthDiff = typeStripped
  ? stringWidth(typeStripped) - typeStripped.length
  : 0;

const space =
  (opts.columns || 0) -
  stringWidth(left) -
  stringWidth(right) -
  2 +
  iconWidthDiff;
```

### Before / After

```
# Before (columns=120, date=true)
ℹ I am a info message                                          9:34:11 PM    ← column 110
✔ I am a success message                                       9:34:11 PM    ← column 110
◐ I am a start message                                          9:34:11 PM    ← column 111 (off by 1)

# After
ℹ I am a info message                                           9:36:38 PM   ← column 111
✔ I am a success message                                        9:36:38 PM   ← column 111
◐ I am a start message                                          9:36:38 PM   ← column 111 (aligned)
```

#### Test plan

- [x] `npx vitest run` — 4/4 pass (3 existing + 1 new regression test)
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] Regression test: verify date position is equal across `info`/`success`/`start`
- [x] Manual verification: time labels now all at same column (was off by 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spacing in formatted logs containing certain Unicode icons.
  * Improved alignment of right-aligned timestamps and tags across supported log types.

* **Tests**
  * Added regression coverage to verify consistent timestamp positioning for informational, success, and start messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->