### PR TITLE
fix(box): measure display width so emoji don't break box borders

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -1,11 +1,10 @@
-import _stringWidth from "string-width";
 import isUnicodeSupported from "is-unicode-supported";
 import { colors } from "../utils/color";
 import { parseStack } from "../utils/error";
 import { FormatOptions, LogObject } from "../types";
 import { LogLevel, LogType } from "../constants";
 import { BoxOpts, box } from "../utils/box";
-import { stripAnsi } from "../utils";
+import { stringWidth } from "../utils";
 import { BasicReporter } from "./basic";
 
 export const TYPE_COLOR_MAP: { [k in LogType]?: string } = {
@@ -36,15 +35,6 @@ const TYPE_ICONS: { [k in LogType]?: string } = {
   start: s("◐", "o"),
   log: "",
 };
-
-function stringWidth(str: string) {
-  // https://github.com/unjs/consola/issues/204
-  const hasICU = typeof Intl === "object";
-  if (!hasICU || !Intl.Segmenter) {
-    return stripAnsi(str).length;
-  }
-  return _stringWidth(str);
-}
 
 export class FancyReporter extends BasicReporter {
   formatStack(stack: string, message: string, opts?: FormatOptions) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ export * from "./utils/box";
 export * from "./utils/color";
 export {
   stripAnsi,
+  stringWidth,
   centerAlign,
   rightAlign,
   leftAlign,

--- a/src/utils/box.ts
+++ b/src/utils/box.ts
@@ -1,5 +1,5 @@
 import { getColor } from "./color";
-import { stripAnsi } from "./string";
+import { stringWidth } from "./string";
 
 export type BoxBorderStyle = {
   /**
@@ -257,8 +257,8 @@ export function box(text: string, _opts: BoxOpts = {}) {
   const height = textLines.length + paddingOffset;
   const width =
     Math.max(
-      ...textLines.map((line) => stripAnsi(line).length),
-      opts.title ? stripAnsi(opts.title).length : 0,
+      ...textLines.map((line) => stringWidth(line)),
+      opts.title ? stringWidth(opts.title) : 0,
     ) + paddingOffset;
   const widthOffset = width + paddingOffset;
 
@@ -273,13 +273,10 @@ export function box(text: string, _opts: BoxOpts = {}) {
   if (opts.title) {
     const title = _color ? _color(opts.title) : opts.title;
     const left = borderStyle.h.repeat(
-      Math.floor((width - stripAnsi(opts.title).length) / 2),
+      Math.floor((width - stringWidth(opts.title)) / 2),
     );
     const right = borderStyle.h.repeat(
-      width -
-        stripAnsi(opts.title).length -
-        stripAnsi(left).length +
-        paddingOffset,
+      width - stringWidth(opts.title) - stringWidth(left) + paddingOffset,
     );
     boxLines.push(
       `${leftSpace}${borderStyle.tl}${left}${title}${right}${borderStyle.tr}`,
@@ -312,7 +309,7 @@ export function box(text: string, _opts: BoxOpts = {}) {
       // Text line
       const line = textLines[i - valignOffset];
       const left = " ".repeat(paddingOffset);
-      const right = " ".repeat(width - stripAnsi(line).length);
+      const right = " ".repeat(width - stringWidth(line));
       boxLines.push(
         `${leftSpace}${borderStyle.v}${left}${line}${right}${borderStyle.v}`,
       );

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,5 @@
+import _stringWidth from "string-width";
+
 const ansiRegex = [
   String.raw`[\u001B\u009B][[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d\/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d\/#&.:=?%@~_]*)*)?\u0007)`,
   String.raw`(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))`,
@@ -13,6 +15,23 @@ const ansiRegex = [
  */
 export function stripAnsi(text: string) {
   return text.replace(new RegExp(ansiRegex, "g"), "");
+}
+
+/**
+ * Returns the visual width of a string in terminal columns, accounting for ANSI
+ * escape codes and wide/emoji characters. Falls back to code-unit length when
+ * `Intl.Segmenter` is unavailable.
+ *
+ * @param {string} str - The string to measure.
+ * @returns {number} The number of columns the string occupies.
+ */
+export function stringWidth(str: string): number {
+  // https://github.com/unjs/consola/issues/204
+  const hasICU = typeof Intl === "object";
+  if (!hasICU || !Intl.Segmenter) {
+    return stripAnsi(str).length;
+  }
+  return _stringWidth(str);
 }
 
 /**

--- a/test/box.test.ts
+++ b/test/box.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "vitest";
+import { box } from "../src/utils/box";
+import { stringWidth } from "../src/utils/string";
+
+describe("box", () => {
+  // https://github.com/unjs/consola/issues/402
+  test("keeps borders aligned when content contains emoji", () => {
+    // "👨‍👩‍👧" is a ZWJ sequence: many code units (`.length` overcounts badly)
+    // but only 2 display columns. With `.length` the border zig-zags.
+    const rendered = box("a short line\n👨‍👩‍👧 family");
+    const widths = rendered
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => stringWidth(line));
+
+    // every rendered line must share the same visual width
+    expect([...new Set(widths)]).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #402.

`box()` measured line width with `stripAnsi(line).length`, which counts UTF-16 code units, not display columns. Emoji — especially surrogate pairs and ZWJ sequences (e.g. `👨‍👩‍👧`, whose `.length` is 8 but occupies 2 columns) — throw off the right-padding, so the border zig-zags.

This reuses the `stringWidth` helper that `fancy.ts` already had — moved into `utils/string.ts` so both share **one** implementation (no duplication) — replacing the 6 `.length` measurements in `box.ts`. `stringWidth` uses `Intl.Segmenter` + `string-width`, falling back to `.length` when ICU is unavailable (the same behaviour the reporter already relied on).

Adds `test/box.test.ts` asserting every rendered line shares one display width for emoji content.

---
_Disclosure: this change was written with AI assistance. I've reviewed, tested, and understand it, and I'll maintain it._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal layout sizing for wide characters, emoji, and ANSI-styled text.
  * Fixed box and report formatting to maintain consistent visual widths across rendered lines.

* **Tests**
  * Added coverage for multiline content containing family emojis and other wide characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->