### PR TITLE
fix: preserve the raw flag of logs queued during a pause

### DIFF
--- a/src/consola.ts
+++ b/src/consola.ts
@@ -311,7 +311,7 @@ export class Consola {
     // Process queue
     const _queue = queue.splice(0);
     for (const item of _queue) {
-      item[0]._logFn(item[1], item[2]);
+      item[0]._logFn(item[1], item[2], item[3]);
     }
   }
 

--- a/test/consola.test.ts
+++ b/test/consola.test.ts
@@ -56,6 +56,54 @@ describe("consola", () => {
 
     expect(logs.at(-1)!.args).toEqual(["SPAM", "(repeated 4 times)"]);
   });
+
+  test("resumeLogs preserves the raw flag of queued logs", () => {
+    const logs: LogObject[] = [];
+    const TestReporter: ConsolaReporter = {
+      log(logObj) {
+        logs.push(logObj);
+      },
+    };
+
+    const consola = createConsola({
+      level: LogLevels.info,
+      reporters: [TestReporter],
+    });
+
+    // reference: a raw log object logged while not paused is passed through as an argument
+    consola.log.raw({ message: "hello" });
+
+    consola.pauseLogs();
+    consola.log.raw({ message: "hello" });
+    consola.resumeLogs();
+
+    expect(logs.length).toBe(2);
+    expect(logs[1].args).toEqual(logs[0].args);
+    expect(logs[1].args).toEqual([{ message: "hello" }]);
+  });
+
+  test("resumeLogs still merges non-raw log objects of queued logs", () => {
+    const logs: LogObject[] = [];
+    const TestReporter: ConsolaReporter = {
+      log(logObj) {
+        logs.push(logObj);
+      },
+    };
+
+    const consola = createConsola({
+      level: LogLevels.info,
+      reporters: [TestReporter],
+    });
+
+    consola.pauseLogs();
+    consola.log({ message: "hello" });
+    consola.resumeLogs();
+
+    expect(logs.length).toBe(1);
+    // a non-raw single log object is merged into the log object, so `message`
+    // becomes the first argument rather than staying a plain argument
+    expect(logs[0].args).toEqual(["hello"]);
+  });
 });
 
 function wait(delay) {


### PR DESCRIPTION
Fixes #438.

### Problem

`_wrapLogFn` stores `isRaw` as the fourth entry of the queue item:

```ts
queue.push([this, defaults, args, isRaw]);
```

but `resumeLogs` only forwarded the first three:

```ts
item[0]._logFn(item[1], item[2]); // item[3] never passed
```

so `_logFn` always received `isRaw === undefined` when replaying a queued log. That falsy value activates the log-object branch:

```ts
if (!isRaw && args.length === 1 && isLogObj(args[0])) {
  Object.assign(logObj, args[0]);
}
```

A `.raw()` call made while paused therefore behaves differently from the same call made without a pause: a single log-object argument is merged into the log object instead of being passed through as an argument.

```ts
const c = createConsola({ reporters: [{ log: obj => console.log(JSON.stringify(obj.args)) }] });

c.log.raw({ message: "hello" });   // [{"message":"hello"}]

c.pauseLogs();
c.log.raw({ message: "hello" });
c.resumeLogs();                    // ["hello"]  <- before this PR
```

### Fix

Forward `item[3]` in `resumeLogs`.

### Tests

`test/consola.test.ts` had no coverage for `pauseLogs`/`resumeLogs` at all, so this adds two tests:

- **`resumeLogs preserves the raw flag of queued logs`** — logs the same raw object once without a pause and once through a pause/resume cycle, and asserts both reporter calls receive identical `args`. It fails on `main` and passes with the fix.
- **`resumeLogs still merges non-raw log objects of queued logs`** — pins the *non-raw* queued path so the fix does not accidentally make every replayed log raw.

### Validation

- `npx vitest run` -> 5 passed (5)
- `pnpm lint` (`eslint .` + `prettier -c src examples test`) -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved raw log output when queued messages are replayed after logging resumes.
  * Ensured queued standard log objects retain their expected message formatting.

* **Tests**
  * Added coverage for raw and standard queued log behavior when logging resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->